### PR TITLE
fix(tui): show checkmark once model download completes

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -872,25 +872,46 @@ mod tui {
                 Style::default().fg(Color::DarkGray),
             )));
         } else if app.switching_model {
-            let frame_str = app.switching_frame();
-            let progress_str = if let Some((downloaded, expected)) = app.download_progress {
-                if expected > 0 {
-                    let pct = (downloaded as f64 / expected as f64 * 100.0).min(100.0) as u8;
-                    let dl_str = format_size_human(downloaded);
-                    let ex_str = format_size_human(expected);
-                    format!(" — {dl_str} / {ex_str} ({pct}%)")
-                } else if downloaded > 0 {
-                    format!(" — {} downloaded", format_size_human(downloaded))
+            // Once the weights have fully landed on disk, swap the spinner for a
+            // checkmark so it's clear the download finished and we're now loading
+            // the model into memory (which can still take a while).
+            let download_complete = matches!(
+                app.download_progress,
+                Some((downloaded, expected)) if expected > 0 && downloaded >= expected
+            );
+
+            if download_complete {
+                let size_str = app
+                    .download_progress
+                    .map(|(_, expected)| format!(" ({})", format_size_human(expected)))
+                    .unwrap_or_default();
+                lines.push(Line::from(vec![
+                    Span::styled("  ✓ ", Style::default().fg(Color::Green)),
+                    Span::styled(
+                        format!("model downloaded{size_str} — loading into memory…"),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                ]));
+            } else {
+                let progress_str = if let Some((downloaded, expected)) = app.download_progress {
+                    if expected > 0 {
+                        let pct = (downloaded as f64 / expected as f64 * 100.0).min(100.0) as u8;
+                        let dl_str = format_size_human(downloaded.min(expected));
+                        let ex_str = format_size_human(expected);
+                        format!(" — {dl_str} / {ex_str} ({pct}%)")
+                    } else if downloaded > 0 {
+                        format!(" — {} downloaded", format_size_human(downloaded))
+                    } else {
+                        String::new()
+                    }
                 } else {
                     String::new()
-                }
-            } else {
-                String::new()
-            };
-            lines.push(Line::from(Span::styled(
-                format!("  {frame_str} switching model{progress_str}…"),
-                Style::default().fg(Color::DarkGray),
-            )));
+                };
+                lines.push(Line::from(Span::styled(
+                    format!("  {} switching model{progress_str}…", app.switching_frame()),
+                    Style::default().fg(Color::DarkGray),
+                )));
+            }
         }
 
         let total_lines = lines.len() as u16;

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,16 +46,15 @@ use onde::inference::SamplingConfig;
 
 use agent_client_protocol::schema::{
     AgentCapabilities, AuthMethod, AuthMethodAgent, AuthenticateRequest, AuthenticateResponse,
-    AvailableCommand, AvailableCommandInput, AvailableCommandsUpdate, ConfigOptionUpdate,
-    UnstructuredCommandInput,
-    CancelNotification, ContentBlock, ContentChunk, EmbeddedResourceResource, ForkSessionRequest,
+    AvailableCommand, AvailableCommandInput, AvailableCommandsUpdate, CancelNotification,
+    ConfigOptionUpdate, ContentBlock, ContentChunk, EmbeddedResourceResource, ForkSessionRequest,
     ForkSessionResponse, Implementation, InitializeRequest, InitializeResponse, LoadSessionRequest,
     LoadSessionResponse, Meta, NewSessionRequest, NewSessionResponse, PromptRequest,
     PromptResponse, ProtocolVersion, SessionCapabilities, SessionConfigOption,
     SessionConfigOptionCategory, SessionConfigSelectOption, SessionConfigValueId,
     SessionForkCapabilities, SessionId, SessionNotification, SessionUpdate,
     SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, StopReason, ToolCall,
-    ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
+    ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, UnstructuredCommandInput,
 };
 use agent_client_protocol::{Agent, ByteStreams, Client, ConnectionTo, Responder};
 use onde::inference::{ChatEngine, GgufModelConfig};
@@ -308,8 +307,7 @@ impl SiGitAgent {
     ) -> Self {
         let startup_model_name = initial_model.display_name.clone();
         let startup_model_id = initial_model.model_id.clone();
-        let backend: Arc<dyn InferenceBackend> =
-            Arc::new(LocalBackend::new(Arc::clone(&engine)));
+        let backend: Arc<dyn InferenceBackend> = Arc::new(LocalBackend::new(Arc::clone(&engine)));
         Self {
             engine,
             backend: tokio::sync::Mutex::new(backend),
@@ -590,10 +588,11 @@ impl SiGitAgent {
         };
         let commands = vec![
             AvailableCommand::new("help", "Show available commands"),
-            AvailableCommand::new("models", "List available models")
-                .input(AvailableCommandInput::Unstructured(
-                    UnstructuredCommandInput::new("model number to switch to (optional)"),
+            AvailableCommand::new("models", "List available models").input(
+                AvailableCommandInput::Unstructured(UnstructuredCommandInput::new(
+                    "model number to switch to (optional)",
                 )),
+            ),
             with_hint("login", "Sign in to siGit Code Cloud", "<email> <password>"),
             AvailableCommand::new("logout", "Sign out of siGit Code Cloud"),
             AvailableCommand::new("whoami", "Show the signed-in account"),
@@ -1276,8 +1275,12 @@ impl SiGitAgent {
         .ok();
         self.advertise_commands(cx, session_id.clone());
 
-        self.send_assistant_message(cx, session_id, format!("Reloaded. {signed_in} {backend_note}"))
-            .ok();
+        self.send_assistant_message(
+            cx,
+            session_id,
+            format!("Reloaded. {signed_in} {backend_note}"),
+        )
+        .ok();
     }
 
     async fn handle_set_session_config_option(


### PR DESCRIPTION
## Summary

Fixes #4.

During an in-chat model switch, the progress line kept spinning at `⁞ switching model … (100%)…` even after the download had finished and the weights were loading into memory, so it read as stuck. The size readout could also show something like `9.36 GB / 4.78 GB`, because the on-disk check sums the whole cache directory but compares it against just the gguf's expected size.

## Changes

- Once the weights have fully landed on disk (`downloaded >= expected`), the spinner becomes a green `✓` and the label reads `model downloaded (<size>) — loading into memory…`.
- While downloading, the shown size is capped at the expected size, so it no longer overshoots 100% or prints `9.36 GB / 4.78 GB`.
- After the load finishes, the existing `✓ Switched to <model>` message shows up like before.

All of this is in `render_messages` in `src/chat.rs`. `cargo build` passes.

## Before and after

Before: `⁞ switching model — 9.36 GB / 4.78 GB (100%)…`, spinning with no end.
After: `✓ model downloaded (4.78 GB) — loading into memory…`