### PR TITLE
fix(acp): put cloud model-switch confirmation on its own line

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1333,7 +1333,10 @@ impl SiGitAgent {
                 Some(display_name) => format!("Switched to {display_name}."),
                 None => CLOUD_LOGIN_PROMPT.to_string(),
             };
-            self.send_assistant_message(cx, args.session_id.clone(), message)
+            // Start on a fresh line: ACP clients concatenate consecutive
+            // agent-message chunks into one block, so without this the switch
+            // confirmation runs onto the end of the previous assistant message.
+            self.send_assistant_message(cx, args.session_id.clone(), format!("\n\n{message}"))
                 .ok();
 
             let current = self.current_model.lock().unwrap().clone();


### PR DESCRIPTION
When a user selects a siGit Code Cloud tier from the editor's model dropdown, the "Switched to …" confirmation was emitted as an agent message chunk that ACP clients (e.g. Zed) concatenate onto the end of the previous assistant message, producing output like "…ready to take on a task.Switched to siGit Code Cloud · Fast."

Prefix the confirmation with a line break so it renders on its own line.

Fixes #12


Claude-Session: https://claude.ai/code/session_016dbjvswLakXTFWt9w6Ew86