### PR TITLE
Bump ACP SDK to v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e037424fa2da7aea1363b42e0c792d117b4d0ceb9d6d6f58719ce7520c22eabf"
+checksum = "5efba6592048ef8a9ac97de8d79b2d9933d8ac4d94f7a2de102348fed0c61103"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "0.11.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabdc9d845d08ec7ed2d0c9de1ae4a1b198301407d55855261572761be90ec9f"
+checksum = "4d176a10d4cb06e0262a738c3c5bf21ff0968db13a666e31cbca94a3d3d72e7c"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.13.4"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd79d476e25d8562d46b368eb5fc629edd3dd6be75e6b036606e6f4f867e7e7"
+checksum = "c290bfa00c6b52339db66f8e9cf711d5f08530800529f7d619ff24d6cba253d0"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 # ACP protocol SDK
-agent-client-protocol = { version = "0.13", features = ["unstable_session_fork", "unstable_session_additional_directories", "unstable_auth_methods"] }
+agent-client-protocol = { version = "0.14", features = ["unstable_session_fork", "unstable_auth_methods"] }
 
 # Onde Inference engine (local LLM)
 # onde = { path = "../onde" }


### PR DESCRIPTION
Updates `agent-client-protocol` from 0.13 to 0.14.

The one thing that mattered for us: 0.14.0 removed the `unstable_session_additional_directories` feature. That field is stable now, so I dropped the flag from the dependency. The other two unstable flags we rely on, `session_fork` and `auth_methods`, are unchanged.

No call sites needed touching. The `additional_directories` reads in `src/main.rs` (new/load/fork session) compile as-is.

## Checks

- `cargo build` clean
- `cargo clippy --tests -- -D warnings` clean
- `cargo fmt -- --check` clean
- `cargo test` 78 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)