### PR TITLE
Add tool permission system: approval prompts, policy, plan mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,10 +63,10 @@ Run a single test: `cargo test <test_name>`.
 
 ## Critical platform constraint: `#[cfg(unix)]` dead code
 
-The interactive client, the `InferenceBackend` seam (`backend.rs`), and provider resolution
-(`provider.rs`) are wired up **only** through `#[cfg(unix)]` code paths. On Windows the binary
-runs ACP-only and drives `onde` directly, so much of `backend.rs` and `provider.rs` is
-legitimately unused there and the dead-code lint is suppressed *on non-Unix targets only*.
+The interactive client is `#[cfg(unix)]`-only. The `InferenceBackend` seam (`backend.rs`) and
+provider resolution (`provider.rs`) are consumed by both the interactive client and the ACP
+server, but several of their items are reached only through the Unix-only interactive paths, so
+the dead-code lint is suppressed *on non-Unix targets only*.
 
 Consequence: code can pass clippy on macOS/Linux but fail on the Windows target (or vice versa).
 When touching `backend.rs`, `provider.rs`, or the interactive path, keep the `cfg` gates intact —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,13 @@ a task, ticket, or session id (not `feature/task-q003hm`).
 **IMPORTANT — pull request target:** Always open pull requests against the `development` branch,
 never `main`. `main` is release-only; `development` is where day-to-day work integrates.
 
+**IMPORTANT — branch off `development`:** Start every working branch from the latest
+`origin/development`. Exception: when new work *depends on* a feature branch that has not merged
+yet (e.g. it builds on tools or APIs that branch introduces), it may be stacked on top of that
+branch instead. When stacking: merge the base PR into `development` first, then rebase the
+stacked branch onto `development` before opening its pull request, so each PR shows only its own
+commits.
+
 **IMPORTANT — run CI before pushing:** Run the full CI gate locally and confirm it is green
 *before* pushing a branch or opening a pull request — never push work that fails these:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,17 @@ feeds results back. Neither the loop nor ACP/TUI surfaces depend on a concrete b
   official server (`<cloud>/mcp`, default `https://sigit.si/api/v1/mcp`) is baked in and authed with the
   cloud session token; extra servers live in `mcp.toml` (global `$SIGIT_CONFIG_DIR/mcp.toml` and
   project-local `.sigit/mcp.toml`). stdio transport is not supported.
+- **`src/permissions.rs`** — tool permission policy. Every tool call passes through
+  `decision_for` before executing: read-only tools always run; mutating tools (and all
+  `mcp__*`/unknown tools) are governed by, in order: per-session plan mode (`/plan` — deny all
+  mutating tools with a present-a-plan message), session "always allow" grants, per-tool
+  overrides and the default mode from `[permissions]` in `settings.toml` (`allow`/`ask`/`deny`,
+  default `ask`; `SIGIT_PERMISSIONS` env overrides the default). On `ask`, the ACP path sends
+  `session/request_permission` (allow once / allow for session / deny) and the TUI pauses the
+  inference task on a y/a/n prompt. Note: ACP turn-affecting handlers run in `cx.spawn`ed tasks
+  serialized by `SiGitAgent::turn_lock` so the dispatch loop can route the client's permission
+  answer mid-turn — don't move them back inline, and don't await client requests from inline
+  handlers (deadlock).
 - **`src/instructions.rs`** — project instruction files, the always-on counterpart to skills.
   Reads `AGENTS.md` (the cross-tool [agents.md](https://agents.md) standard) and `CLAUDE.md`,
   walking from the session cwd up to the repo root (nearest ancestor with `.git`, never above it),
@@ -120,8 +131,8 @@ feeds results back. Neither the loop nor ACP/TUI surfaces depend on a concrete b
 - **`src/models.rs`** — model-picker types shared across platforms.
 
 Slash commands (`/help`, `/models`, `/skills`, `/mcp`, `/login`, `/logout`, `/whoami`, `/reload`,
-`/clear`, `/status`) are advertised via `advertise_commands` in `main.rs` and handled in both the
-TUI and ACP sessions.
+`/plan`, `/permissions`, `/clear`, `/status`) are advertised via `advertise_commands` in `main.rs`
+and handled in both the TUI and ACP sessions.
 
 ## Model cache (macOS)
 
@@ -142,7 +153,9 @@ verbosity with `RUST_LOG`.
 `OPENAI_BASE_URL` / `OPENAI_API_KEY` (provider override), `SIGIT_API_URL` (account API base,
 default `https://sigit.si`), `SIGIT_CLOUD_URL`, `SIGIT_CONFIG_DIR` (default `~/.config/sigit`),
 `SIGIT_MODEL`, `SIGIT_MCP` (`off` disables MCP), `SIGIT_MCP_OFFICIAL` (`off` drops the baked-in
-server), `HF_HOME` / `HF_HUB_CACHE`, `RUST_LOG`.
+server), `SIGIT_PERMISSIONS` (`allow`/`ask`/`deny` — overrides the default permission mode for
+mutating tools; the escape hatch for clients without permission-request support),
+`HF_HOME` / `HF_HUB_CACHE`, `RUST_LOG`.
 
 ## Releasing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,11 @@ Before the TTY/ACP split, `main` also dispatches the account subcommands `sigit 
 
 ## Working in this repo
 
-**IMPORTANT — branch naming:** Name every working branch after the *changes it contains*, not
-after a task, ticket, or session id. Use a short, descriptive, kebab-case slug so the branch is
-self-explanatory from its name alone (e.g. `claude/agent-tools-multiedit-glob-todos-remember`,
-not `claude/task-q003hm`).
+**IMPORTANT — branch naming:** Prefix every working branch with `feature/` (new functionality)
+or `fix/` (bug fixes) — never a tool- or agent-name prefix like `claude/`. Name the branch after
+the *changes it contains*, as a short, descriptive, kebab-case slug that is self-explanatory
+from the name alone (e.g. `feature/tool-permission-system`, `fix/glob-mtime-sort`), never after
+a task, ticket, or session id (not `feature/task-q003hm`).
 
 **IMPORTANT — pull request target:** Always open pull requests against the `development` branch,
 never `main`. `main` is release-only; `development` is where day-to-day work integrates.

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -98,6 +98,14 @@ pub trait InferenceBackend: Send + Sync {
         sink: Option<&TokenSink>,
     ) -> Result<TurnResult, BackendError>;
 
+    /// Record tool results in the conversation history *without* asking the
+    /// model to continue the turn. Used when a turn is abandoned mid-round
+    /// (the user cancelled at the permission gate): by then the assistant
+    /// message carrying the tool calls is already in history, and leaving them
+    /// unanswered makes strict OpenAI-compatible endpoints reject every later
+    /// request in the session.
+    async fn record_cancelled_tool_results(&self, results: Vec<ToolResult>);
+
     /// Whether inference runs over the network (a configured provider) rather
     /// than on-device. Drives UI labelling so the displayed model can't claim a
     /// local model while requests actually go to the cloud.
@@ -193,6 +201,13 @@ impl InferenceBackend for LocalBackend {
             .await
             .map_err(|error| error.to_string())?;
         Ok(onde_result_to_turn(result))
+    }
+
+    async fn record_cancelled_tool_results(&self, _results: Vec<ToolResult>) {
+        // onde's public API cannot append tool-result history entries without
+        // running another inference round, so the dangling tool call stays in
+        // its history. The chat template replays it as-is, which local models
+        // tolerate — worst case the model re-issues the call next turn.
     }
 
     fn is_remote(&self) -> bool {
@@ -562,6 +577,17 @@ impl InferenceBackend for OpenAiBackend {
         self.complete(tools, sink).await
     }
 
+    async fn record_cancelled_tool_results(&self, results: Vec<ToolResult>) {
+        let mut history = self.history.lock().await;
+        for result in results {
+            history.push(serde_json::json!({
+                "role": "tool",
+                "tool_call_id": result.tool_call_id,
+                "content": result.content,
+            }));
+        }
+    }
+
     fn is_remote(&self) -> bool {
         true
     }
@@ -725,6 +751,36 @@ mod tests {
             value["tool_calls"][0]["function"]["arguments"],
             r#"{"path":"a.rs"}"#
         );
+    }
+
+    #[tokio::test]
+    async fn cancelled_tool_results_close_out_history() {
+        let backend = OpenAiBackend::new("http://localhost", "", "test-model", None);
+        backend
+            .history
+            .lock()
+            .await
+            .push(streamed_assistant_history(
+                "",
+                &[ToolCall {
+                    id: "call_9".to_string(),
+                    name: "run_command".to_string(),
+                    arguments: r#"{"command":"ls"}"#.to_string(),
+                }],
+            ));
+
+        backend
+            .record_cancelled_tool_results(vec![ToolResult {
+                tool_call_id: "call_9".to_string(),
+                content: "cancelled by the user".to_string(),
+            }])
+            .await;
+
+        let history = backend.history.lock().await;
+        let last = history.last().unwrap();
+        assert_eq!(last["role"], "tool");
+        assert_eq!(last["tool_call_id"], "call_9");
+        assert_eq!(last["content"], "cancelled by the user");
     }
 
     #[test]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -11,11 +11,11 @@
 //! The trait exposes neither `onde` nor OpenAI types, so the loop does not depend
 //! on a specific backend.
 //!
-//! The whole backend seam is wired up only through the interactive client, which
-//! is `#[cfg(unix)]` (see `run_interactive` in `main.rs` and `mod tui` in
-//! `chat.rs`). On non-Unix targets the binary runs ACP-only and drives `onde`
-//! directly, so every item here is legitimately unused there. Suppress the
-//! dead-code lint on those targets only — Unix builds still get full coverage.
+//! The seam is consumed by both surfaces: the interactive client (`#[cfg(unix)]`,
+//! see `run_interactive` in `main.rs` and `mod tui` in `chat.rs`) and the ACP
+//! server's prompt loop. Some items are still reached only through the
+//! Unix-only interactive paths, so the dead-code lint stays suppressed on
+//! non-Unix targets only — Unix builds keep full coverage.
 #![cfg_attr(not(unix), allow(dead_code))]
 
 use std::sync::Arc;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1606,6 +1606,27 @@ mod tui {
         specs
     }
 
+    /// Close out a cancelled round in backend history: the results of tools
+    /// that already ran this round, plus cancellation notes for `unreached`
+    /// calls. Leaving a round's tool calls unanswered breaks strict
+    /// OpenAI-compatible endpoints on the session's next request.
+    async fn abandon_round(
+        backend: &dyn InferenceBackend,
+        mut tool_results: Vec<ToolResult>,
+        unreached: &[crate::backend::ToolCall],
+    ) {
+        for pending in unreached {
+            tool_results.push(ToolResult {
+                tool_call_id: pending.id.clone(),
+                content: format!(
+                    "`{}` was not executed: the user cancelled the turn.",
+                    pending.name
+                ),
+            });
+        }
+        backend.record_cancelled_tool_results(tool_results).await;
+    }
+
     /// run the tool-calling loop off the main thread, posting updates via `tx`.
     /// dropping `tx` signals completion to the event loop.
     async fn run_inference_task(
@@ -1667,7 +1688,16 @@ mod tui {
 
             let mut tool_results = Vec::new();
 
-            for tc in &result.tool_calls {
+            for (call_index, tc) in result.tool_calls.iter().enumerate() {
+                // The UI drops the receiver on Ctrl+C or quit. Stop the turn
+                // at the next boundary instead of burning model rounds (and
+                // possibly running granted tools) in the background.
+                if tx.is_closed() {
+                    log::info!("turn cancelled by the user — stopping the tool loop");
+                    abandon_round(&*backend, tool_results, &result.tool_calls[call_index..]).await;
+                    return;
+                }
+
                 log::info!(
                     "  → {}({})",
                     tc.name,
@@ -1703,11 +1733,25 @@ mod tui {
                                 permissions::grant_for_session(TUI_SESSION, &tc.name);
                                 crate::tools::execute_tool(&tc.name, &tc.arguments).await
                             }
-                            // An explicit "no", or the UI dropped the channel
-                            // (cancel/quit) — either way, do not run the tool.
-                            Ok(ApprovalChoice::Deny) | Err(_) => {
+                            Ok(ApprovalChoice::Deny) => {
                                 log::info!("  ✗ {} denied by user", tc.name);
                                 permissions::user_denial(&tc.name)
+                            }
+                            // The UI dropped the reply channel (Ctrl+C or
+                            // quit): the whole turn is over, not just this
+                            // call. Close out the round and stop instead of
+                            // continuing rounds in the background.
+                            Err(_) => {
+                                log::info!(
+                                    "turn cancelled at the approval prompt — stopping the tool loop"
+                                );
+                                abandon_round(
+                                    &*backend,
+                                    tool_results,
+                                    &result.tool_calls[call_index..],
+                                )
+                                .await;
+                                return;
                             }
                         }
                     }
@@ -1718,6 +1762,14 @@ mod tui {
                     tool_call_id: tc.id.clone(),
                     content: output,
                 });
+            }
+
+            // Cancelled while the round's tools ran: record what executed and
+            // stop before paying for another model round nobody will see.
+            if tx.is_closed() {
+                log::info!("turn cancelled by the user — skipping the next model round");
+                abandon_round(&*backend, tool_results, &[]).await;
+                return;
             }
 
             // on the last round, pass no tools so the model must produce text —

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -88,7 +88,7 @@ mod tui {
         text::{Line, Span},
         widgets::{Block, Borders, Clear, Paragraph, Wrap},
     };
-    use tokio::sync::mpsc;
+    use tokio::sync::{mpsc, oneshot};
     use tokio::time::{Duration, Instant, interval};
 
     // ── Message types ─────────────────────────────────────────────────────────
@@ -157,6 +157,23 @@ mod tui {
         /// a complete (non-streamed) assistant reply
         Response(String),
         Error(String),
+        /// the inference task wants to run a mutating tool and is paused on
+        /// `reply`; the user answers with y (once) / a (session) / n (deny)
+        ApprovalRequest {
+            tool: String,
+            reply: oneshot::Sender<ApprovalChoice>,
+        },
+    }
+
+    /// The user's answer to a tool-approval prompt. Dropping the reply channel
+    /// (quit, cancel) counts as a denial on the inference side.
+    enum ApprovalChoice {
+        /// run this one call
+        Once,
+        /// run it and stop asking for this tool for the rest of the session
+        Session,
+        /// skip the call; the model gets an explanatory tool result
+        Deny,
     }
 
     enum ModelLoadUpdate {
@@ -175,6 +192,9 @@ mod tui {
         stream_buf: String,
         inference_rx: Option<mpsc::Receiver<InferenceUpdate>>,
         model_load_rx: Option<mpsc::Receiver<ModelLoadUpdate>>,
+        /// a tool call waiting on the user's y/a/n answer; the inference task is
+        /// paused on the other end of the channel
+        pending_approval: Option<(String, oneshot::Sender<ApprovalChoice>)>,
         thinking: bool,
         thinking_tick: u8,
         quit: bool,
@@ -270,6 +290,7 @@ mod tui {
                 stream_buf: String::new(),
                 inference_rx: None,
                 model_load_rx: None,
+                pending_approval: None,
                 thinking: false,
                 thinking_tick: 0,
                 quit: false,
@@ -342,6 +363,9 @@ mod tui {
         fn stop_thinking(&mut self) {
             self.thinking = false;
             self.inference_rx = None;
+            // Dropping a pending reply channel reads as a denial on the
+            // inference side, so a cancelled turn can't leave a tool waiting.
+            self.pending_approval = None;
         }
 
         fn tick_thinking(&mut self) {
@@ -746,6 +770,11 @@ mod tui {
         Login(Option<String>),
         Logout,
         Whoami,
+        /// Toggle plan mode (research only; mutating tools are denied with a
+        /// prompt to present a plan). `Some(true/false)` sets it, `None` flips it.
+        Plan(Option<bool>),
+        /// Show the effective permission policy for this session.
+        Permissions,
         Exit,
         Unknown(String),
     }
@@ -770,6 +799,8 @@ mod tui {
             "/login" => SlashCommand::Login(arg.map(str::to_string)),
             "/logout" => SlashCommand::Logout,
             "/whoami" => SlashCommand::Whoami,
+            "/plan" => SlashCommand::Plan(parse_on_off(arg)),
+            "/permissions" => SlashCommand::Permissions,
             "/exit" | "/quit" | "/q" => SlashCommand::Exit,
             other => SlashCommand::Unknown(other.to_string()),
         })
@@ -1139,7 +1170,12 @@ mod tui {
             Span::styled(" quit", Style::default().fg(Color::DarkGray)),
         ];
 
-        if app.thinking || app.switching_model || app.is_streaming() {
+        if let Some((tool, _)) = &app.pending_approval {
+            spans.push(Span::styled(
+                format!("  allow {tool}? [y]es · [a]lways · [n]o"),
+                Style::default().fg(Color::Yellow),
+            ));
+        } else if app.thinking || app.switching_model || app.is_streaming() {
             spans.push(Span::styled(
                 "  (busy — Ctrl+C to cancel)",
                 Style::default().fg(Color::Yellow),
@@ -1367,6 +1403,8 @@ mod tui {
                      /login E P     — sign in to siGit Code Cloud\n\
                      /logout        — sign out\n\
                      /whoami        — show the signed-in account\n\
+                     /plan [on|off] — plan mode: research only, no edits or commands\n\
+                     /permissions   — show the tool permission policy\n\
                      /clear         — wipe conversation history\n\
                      /status        — show engine status\n\
                      /exit          — quit chat",
@@ -1375,9 +1413,28 @@ mod tui {
             SlashCommand::Clear => {
                 let cleared = engine.clear_history().await;
                 app.messages.clear();
+                crate::permissions::reset_session(crate::permissions::TUI_SESSION);
                 app.messages.push(ChatMessage::system(format!(
                     "Cleared {cleared} turn(s). History is empty.",
                 )));
+            }
+            SlashCommand::Plan(value) => {
+                use crate::permissions::{self, TUI_SESSION};
+                let enabled = value.unwrap_or_else(|| !permissions::plan_mode(TUI_SESSION));
+                permissions::set_plan_mode(TUI_SESSION, enabled);
+                app.messages.push(ChatMessage::system(if enabled {
+                    "Plan mode ON — research with read-only tools only; edits and commands \
+                     are blocked until /plan off."
+                } else {
+                    "Plan mode OFF — tools may execute again (subject to the permission \
+                     policy)."
+                }));
+            }
+            SlashCommand::Permissions => {
+                app.messages
+                    .push(ChatMessage::system(crate::permissions::describe(
+                        crate::permissions::TUI_SESSION,
+                    )));
             }
             SlashCommand::Status => {
                 let info = engine.as_ref().info().await;
@@ -1617,7 +1674,41 @@ mod tui {
 
                 let _ = tx.send(InferenceUpdate::ToolUse(tc.name.clone())).await;
 
-                let output = crate::tools::execute_tool(&tc.name, &tc.arguments).await;
+                // Permission gate: read-only tools pass straight through; a
+                // mutating tool consults policy and may pause on the user's
+                // y/a/n answer (delivered over a oneshot from the event loop).
+                use crate::permissions::{self, Decision, TUI_SESSION};
+                let output = match permissions::decision_for(TUI_SESSION, &tc.name) {
+                    Decision::Allow => crate::tools::execute_tool(&tc.name, &tc.arguments).await,
+                    Decision::Deny(reason) => {
+                        log::info!("  ✗ {} denied by policy", tc.name);
+                        reason
+                    }
+                    Decision::Ask => {
+                        let (reply_tx, reply_rx) = oneshot::channel();
+                        let _ = tx
+                            .send(InferenceUpdate::ApprovalRequest {
+                                tool: tc.name.clone(),
+                                reply: reply_tx,
+                            })
+                            .await;
+                        match reply_rx.await {
+                            Ok(ApprovalChoice::Once) => {
+                                crate::tools::execute_tool(&tc.name, &tc.arguments).await
+                            }
+                            Ok(ApprovalChoice::Session) => {
+                                permissions::grant_for_session(TUI_SESSION, &tc.name);
+                                crate::tools::execute_tool(&tc.name, &tc.arguments).await
+                            }
+                            // An explicit "no", or the UI dropped the channel
+                            // (cancel/quit) — either way, do not run the tool.
+                            Ok(ApprovalChoice::Deny) | Err(_) => {
+                                log::info!("  ✗ {} denied by user", tc.name);
+                                permissions::user_denial(&tc.name)
+                            }
+                        }
+                    }
+                };
                 log::info!("  ← {} chars", output.len());
 
                 tool_results.push(ToolResult {
@@ -1837,6 +1928,12 @@ mod tui {
                             app.stop_thinking();
                             app.messages.push(ChatMessage::system(format!("error: {msg}")));
                         }
+                        Some(InferenceUpdate::ApprovalRequest { tool, reply }) => {
+                            app.messages.push(ChatMessage::system(format!(
+                                "⚠ permission — allow {tool}?  [y]es · [a]lways this session · [n]o"
+                            )));
+                            app.pending_approval = Some((tool, reply));
+                        }
                         None => {
                             // task finished, possibly with no text to show
                             app.finalize_stream();
@@ -1876,6 +1973,53 @@ mod tui {
                                         || key.code == KeyCode::Char('d'))
                                 {
                                     app.quit = true;
+                                }
+                            }
+                            continue;
+                        }
+
+                        // pending tool approval — y/a/n answer the prompt; the
+                        // inference task is paused on the reply channel. Checked
+                        // before the busy gate because the app *is* busy here.
+                        if app.pending_approval.is_some() {
+                            if key.kind == KeyEventKind::Press {
+                                let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+                                let choice = if ctrl
+                                    && (key.code == KeyCode::Char('c')
+                                        || key.code == KeyCode::Char('d'))
+                                {
+                                    // cancel the whole turn: denying is implicit
+                                    // in dropping the reply channel
+                                    app.pending_approval = None;
+                                    app.stop_thinking();
+                                    app.messages.push(ChatMessage::system("(cancelled)"));
+                                    continue;
+                                } else {
+                                    match key.code {
+                                        KeyCode::Char('y') | KeyCode::Char('Y') => {
+                                            Some(ApprovalChoice::Once)
+                                        }
+                                        KeyCode::Char('a') | KeyCode::Char('A') => {
+                                            Some(ApprovalChoice::Session)
+                                        }
+                                        KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                                            Some(ApprovalChoice::Deny)
+                                        }
+                                        _ => None,
+                                    }
+                                };
+                                if let Some(choice) = choice
+                                    && let Some((tool, reply)) = app.pending_approval.take()
+                                {
+                                    let verdict = match &choice {
+                                        ApprovalChoice::Once => "allowed once",
+                                        ApprovalChoice::Session => "allowed for this session",
+                                        ApprovalChoice::Deny => "denied",
+                                    };
+                                    app.messages.push(ChatMessage::system(format!(
+                                        "{tool}: {verdict}"
+                                    )));
+                                    let _ = reply.send(choice);
                                 }
                             }
                             continue;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -161,6 +161,8 @@ mod tui {
         /// `reply`; the user answers with y (once) / a (session) / n (deny)
         ApprovalRequest {
             tool: String,
+            /// arguments preview so the user can see what they are approving
+            args: String,
             reply: oneshot::Sender<ApprovalChoice>,
         },
     }
@@ -1689,6 +1691,7 @@ mod tui {
                         let _ = tx
                             .send(InferenceUpdate::ApprovalRequest {
                                 tool: tc.name.clone(),
+                                args: permissions::approval_preview(&tc.arguments),
                                 reply: reply_tx,
                             })
                             .await;
@@ -1928,9 +1931,14 @@ mod tui {
                             app.stop_thinking();
                             app.messages.push(ChatMessage::system(format!("error: {msg}")));
                         }
-                        Some(InferenceUpdate::ApprovalRequest { tool, reply }) => {
+                        Some(InferenceUpdate::ApprovalRequest { tool, args, reply }) => {
+                            let call = if args.is_empty() {
+                                tool.clone()
+                            } else {
+                                format!("{tool}({args})")
+                            };
                             app.messages.push(ChatMessage::system(format!(
-                                "⚠ permission — allow {tool}?  [y]es · [a]lways this session · [n]o"
+                                "⚠ permission — allow {call}?  [y]es · [a]lways this session · [n]o"
                             )));
                             app.pending_approval = Some((tool, reply));
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1295,7 +1295,7 @@ impl SiGitAgent {
 
             let mut tool_results = Vec::new();
 
-            for tc in &result.tool_calls {
+            for (call_index, tc) in result.tool_calls.iter().enumerate() {
                 log::info!(
                     "  → {}({})",
                     tc.name,
@@ -1326,6 +1326,23 @@ impl SiGitAgent {
                             }
                             PermissionVerdict::TurnCancelled => {
                                 log::info!("prompt({}) cancelled at permission gate", session_id);
+                                // The assistant message carrying these tool
+                                // calls is already in the backend history;
+                                // leaving any of them unanswered makes strict
+                                // OpenAI-compatible endpoints reject every
+                                // later request in the session. Close out this
+                                // call and the ones this round never reached.
+                                for pending in &result.tool_calls[call_index..] {
+                                    tool_results.push(BackendToolResult {
+                                        tool_call_id: pending.id.clone(),
+                                        content: format!(
+                                            "`{}` was not executed: the user cancelled the turn \
+                                             at the permission prompt.",
+                                            pending.name
+                                        ),
+                                    });
+                                }
+                                backend.record_cancelled_tool_results(tool_results).await;
                                 return Ok(PromptResponse::new(StopReason::Cancelled));
                             }
                         }
@@ -1409,12 +1426,18 @@ impl SiGitAgent {
         tool_name: &str,
         arguments: &str,
     ) -> PermissionVerdict {
-        let args_preview: String = arguments.chars().take(120).collect();
+        // The user decides from this dialog, so show the arguments with any
+        // truncation flagged (a silently clipped command could hide its tail
+        // from the person approving it). The full arguments also travel as
+        // `raw_input` for clients that render it.
+        let args_preview = permissions::approval_preview(arguments);
         let title = if args_preview.is_empty() {
             tool_name.to_string()
         } else {
             format!("{tool_name}({args_preview})")
         };
+        let raw_input: serde_json::Value = serde_json::from_str(arguments)
+            .unwrap_or_else(|_| serde_json::Value::String(arguments.to_string()));
 
         let request = RequestPermissionRequest::new(
             session_id.clone(),
@@ -1423,7 +1446,8 @@ impl SiGitAgent {
                 ToolCallUpdateFields::new()
                     .title(title)
                     .kind(tool_kind_for(tool_name))
-                    .status(ToolCallStatus::Pending),
+                    .status(ToolCallStatus::Pending)
+                    .raw_input(raw_input),
             ),
             vec![
                 PermissionOption::new("allow_once", "Allow once", PermissionOptionKind::AllowOnce),

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ mod credentials;
 mod instructions;
 mod mcp;
 mod models;
+mod permissions;
 mod provider;
 mod settings;
 mod setup;
@@ -62,12 +63,13 @@ use agent_client_protocol::schema::v1::{
     AvailableCommand, AvailableCommandInput, AvailableCommandsUpdate, CancelNotification,
     ConfigOptionUpdate, ContentBlock, ContentChunk, EmbeddedResourceResource, ForkSessionRequest,
     ForkSessionResponse, Implementation, InitializeRequest, InitializeResponse, LoadSessionRequest,
-    LoadSessionResponse, Meta, NewSessionRequest, NewSessionResponse, PromptRequest,
-    PromptResponse, SessionCapabilities, SessionConfigOption, SessionConfigOptionCategory,
-    SessionConfigSelectOption, SessionConfigValueId, SessionForkCapabilities, SessionId,
-    SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
-    SetSessionConfigOptionResponse, StopReason, ToolCall, ToolCallStatus, ToolCallUpdate,
-    ToolCallUpdateFields, ToolKind, UnstructuredCommandInput,
+    LoadSessionResponse, Meta, NewSessionRequest, NewSessionResponse, PermissionOption,
+    PermissionOptionKind, PromptRequest, PromptResponse, RequestPermissionOutcome,
+    RequestPermissionRequest, SessionCapabilities, SessionConfigOption,
+    SessionConfigOptionCategory, SessionConfigSelectOption, SessionConfigValueId,
+    SessionForkCapabilities, SessionId, SessionNotification, SessionUpdate,
+    SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, StopReason, ToolCall,
+    ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, UnstructuredCommandInput,
 };
 use agent_client_protocol::{Agent, ByteStreams, Client, ConnectionTo, Responder};
 use onde::inference::{ChatEngine, GgufModelConfig};
@@ -230,6 +232,33 @@ pub(crate) fn system_prompt_for_model(tool_calling: bool) -> &'static str {
 /// cap tool-call loops so a confused model can't spin forever
 const MAX_TOOL_ROUNDS: usize = 10;
 
+/// Outcome of asking the client for permission to run one tool call.
+enum PermissionVerdict {
+    /// Run the tool.
+    Approved,
+    /// Skip the tool; the string becomes its tool result so the model adapts.
+    Denied(String),
+    /// The client cancelled the turn while the request was pending; stop the
+    /// whole prompt with `StopReason::Cancelled` instead of burning rounds.
+    TurnCancelled,
+}
+
+/// Display kind for the permission dialog, so editors can show a fitting icon.
+fn tool_kind_for(tool_name: &str) -> ToolKind {
+    match tool_name {
+        "edit_file" | "multi_edit" | "create_file" | "create_directory" | "remember" => {
+            ToolKind::Edit
+        }
+        "delete_file" => ToolKind::Delete,
+        "run_command" => ToolKind::Execute,
+        "read_file" | "list_directory" => ToolKind::Read,
+        "search_files" | "glob" => ToolKind::Search,
+        "read_website" => ToolKind::Fetch,
+        "write_todos" => ToolKind::Think,
+        _ => ToolKind::Other,
+    }
+}
+
 /// Shown when a siGit Code Cloud tier is selected without a signed-in account.
 const CLOUD_LOGIN_PROMPT: &str = "siGit Code Cloud needs an account. Sign in with \
     `/login <email> <password>` (or the Authenticate button), then pick the tier again. \
@@ -350,6 +379,12 @@ struct SiGitAgent {
     startup_model_name: String,
     /// for download-progress polling
     startup_model_id: String,
+    /// Serializes turn-affecting handlers (prompt, session lifecycle, config
+    /// changes). They run in `cx.spawn`ed tasks so the JSON-RPC dispatch loop
+    /// stays free to route client responses (e.g. permission answers) mid-turn;
+    /// this lock reproduces the strict ordering the dispatch loop used to give
+    /// them for free.
+    turn_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl SiGitAgent {
@@ -375,6 +410,7 @@ impl SiGitAgent {
             startup_needs_download,
             startup_model_name,
             startup_model_id,
+            turn_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
@@ -727,6 +763,12 @@ impl SiGitAgent {
             AvailableCommand::new("logout", "Sign out of siGit Code Cloud"),
             AvailableCommand::new("whoami", "Show the signed-in account"),
             AvailableCommand::new("reload", "Re-sync sign-in and model state"),
+            with_hint(
+                "plan",
+                "Plan mode: research only, no edits or commands",
+                "on|off (optional)",
+            ),
+            AvailableCommand::new("permissions", "Show the tool permission policy"),
             AvailableCommand::new("clear", "Wipe the conversation history"),
             AvailableCommand::new("status", "Show engine status"),
         ];
@@ -906,6 +948,10 @@ impl SiGitAgent {
         if let Ok(mut guard) = self.session_cwd.lock() {
             *guard = Some(args.cwd.clone());
         }
+
+        // A reloaded session starts fresh: grants and plan mode from the
+        // previous life of this session id must not carry over.
+        permissions::reset_session(&args.session_id.to_string());
 
         // tool calls use relative paths, so we need to match the editor's cwd
         if args.cwd.is_dir()
@@ -1256,7 +1302,35 @@ impl SiGitAgent {
                     tc.arguments.chars().take(120).collect::<String>()
                 );
 
-                let output = tools::execute_tool(&tc.name, &tc.arguments).await;
+                // Permission gate: read-only tools pass straight through; a
+                // mutating tool consults policy and may ask the client.
+                let output = match permissions::decision_for(&session_id.to_string(), &tc.name) {
+                    permissions::Decision::Allow => {
+                        tools::execute_tool(&tc.name, &tc.arguments).await
+                    }
+                    permissions::Decision::Deny(reason) => {
+                        log::info!("  ✗ {} denied by policy", tc.name);
+                        reason
+                    }
+                    permissions::Decision::Ask => {
+                        match self
+                            .request_tool_permission(cx, &session_id, &tc.name, &tc.arguments)
+                            .await
+                        {
+                            PermissionVerdict::Approved => {
+                                tools::execute_tool(&tc.name, &tc.arguments).await
+                            }
+                            PermissionVerdict::Denied(reason) => {
+                                log::info!("  ✗ {} denied by user", tc.name);
+                                reason
+                            }
+                            PermissionVerdict::TurnCancelled => {
+                                log::info!("prompt({}) cancelled at permission gate", session_id);
+                                return Ok(PromptResponse::new(StopReason::Cancelled));
+                            }
+                        }
+                    }
+                };
 
                 log::info!("  ← {} chars", output.len());
 
@@ -1321,6 +1395,74 @@ impl SiGitAgent {
 
         log::info!("prompt({}) complete — {} tool round(s)", session_id, round);
         Ok(PromptResponse::new(StopReason::EndTurn))
+    }
+
+    /// Ask the ACP client for permission to run one tool call. Presents
+    /// allow-once / allow-for-session / deny; an "always allow" choice is
+    /// recorded via [`permissions::grant_for_session`]. Only safe to call from
+    /// a spawned task (see the handler registration in `run_acp_server`): the
+    /// dispatch loop must be free to route the client's answer back to us.
+    async fn request_tool_permission(
+        &self,
+        cx: &ConnectionTo<Client>,
+        session_id: &SessionId,
+        tool_name: &str,
+        arguments: &str,
+    ) -> PermissionVerdict {
+        let args_preview: String = arguments.chars().take(120).collect();
+        let title = if args_preview.is_empty() {
+            tool_name.to_string()
+        } else {
+            format!("{tool_name}({args_preview})")
+        };
+
+        let request = RequestPermissionRequest::new(
+            session_id.clone(),
+            ToolCallUpdate::new(
+                format!("perm-{}", uuid::Uuid::new_v4()),
+                ToolCallUpdateFields::new()
+                    .title(title)
+                    .kind(tool_kind_for(tool_name))
+                    .status(ToolCallStatus::Pending),
+            ),
+            vec![
+                PermissionOption::new("allow_once", "Allow once", PermissionOptionKind::AllowOnce),
+                PermissionOption::new(
+                    "allow_session",
+                    "Allow for this session",
+                    PermissionOptionKind::AllowAlways,
+                ),
+                PermissionOption::new("reject_once", "Deny", PermissionOptionKind::RejectOnce),
+            ],
+        );
+
+        match cx.send_request(request).block_task().await {
+            Ok(response) => match response.outcome {
+                RequestPermissionOutcome::Selected(selected) => {
+                    match selected.option_id.0.as_ref() {
+                        "allow_once" => PermissionVerdict::Approved,
+                        "allow_session" => {
+                            permissions::grant_for_session(&session_id.to_string(), tool_name);
+                            PermissionVerdict::Approved
+                        }
+                        _ => PermissionVerdict::Denied(permissions::user_denial(tool_name)),
+                    }
+                }
+                RequestPermissionOutcome::Cancelled => PermissionVerdict::TurnCancelled,
+                // The outcome enum is non_exhaustive; treat anything unknown as
+                // a denial rather than running a mutating tool unapproved.
+                _ => PermissionVerdict::Denied(permissions::user_denial(tool_name)),
+            },
+            Err(error) => {
+                log::warn!("permission request for `{tool_name}` failed: {error}");
+                PermissionVerdict::Denied(format!(
+                    "`{tool_name}` was not executed: this client could not answer the \
+                     permission request ({error}). The user can pre-approve tools in \
+                     settings.toml under [permissions], or set SIGIT_PERMISSIONS=allow \
+                     for clients without permission support."
+                ))
+            }
+        }
     }
 
     async fn handle_cancel(&self, args: CancelNotification) -> agent_client_protocol::Result<()> {
@@ -1977,6 +2119,11 @@ enum SlashCommand {
     Whoami,
     /// Re-sync session state (auth, backend, picker) without a new session.
     Reload,
+    /// Toggle plan mode (read-only research; mutating tools denied with a
+    /// prompt to present a plan). `Some(true/false)` sets it, `None` flips it.
+    Plan(Option<bool>),
+    /// Show the effective permission policy for this session.
+    Permissions,
     Exit,
     Unknown(String),
 }
@@ -2002,6 +2149,8 @@ fn parse_slash(input: &str) -> Option<SlashCommand> {
         "/logout" => SlashCommand::Logout,
         "/whoami" => SlashCommand::Whoami,
         "/reload" => SlashCommand::Reload,
+        "/plan" => SlashCommand::Plan(parse_on_off(argument)),
+        "/permissions" => SlashCommand::Permissions,
         "/exit" | "/quit" | "/q" => SlashCommand::Exit,
         other => SlashCommand::Unknown(other.to_string()),
     })
@@ -2110,6 +2259,8 @@ async fn exec_slash_acp(
                      /logout        - sign out\n\
                      /whoami        - show the signed-in account\n\
                      /reload        - re-sync sign-in and model state\n\
+                     /plan [on|off] - plan mode: research only, no edits or commands\n\
+                     /permissions   - show the tool permission policy\n\
                      /clear         - wipe conversation history\n\
                      /status        - show engine status\n\
                      /exit          - end this turn",
@@ -2118,6 +2269,7 @@ async fn exec_slash_acp(
         }
         SlashCommand::Clear => {
             let cleared = agent.engine.clear_history().await;
+            permissions::reset_session(&session_id.to_string());
             agent
                 .send_assistant_message(
                     cx,
@@ -2125,6 +2277,23 @@ async fn exec_slash_acp(
                     format!("Cleared {cleared} turn(s). History is empty."),
                 )
                 .ok();
+        }
+        SlashCommand::Plan(value) => {
+            let session_key = session_id.to_string();
+            let enabled = value.unwrap_or_else(|| !permissions::plan_mode(&session_key));
+            permissions::set_plan_mode(&session_key, enabled);
+            let message = if enabled {
+                "Plan mode ON — the agent researches with read-only tools and presents a \
+                 plan; edits and commands are blocked until /plan off."
+            } else {
+                "Plan mode OFF — the agent may execute tools again (subject to the \
+                 permission policy)."
+            };
+            agent.send_assistant_message(cx, session_id, message).ok();
+        }
+        SlashCommand::Permissions => {
+            let summary = permissions::describe(&session_id.to_string());
+            agent.send_assistant_message(cx, session_id, summary).ok();
         }
         SlashCommand::Status => {
             let info = agent.engine.info().await;
@@ -2677,11 +2846,21 @@ async fn run_acp_server() -> anyhow::Result<()> {
             },
             agent_client_protocol::on_receive_request!(),
         )
+        // Turn-affecting handlers below run in spawned tasks, serialized by
+        // `turn_lock`, so the dispatch loop stays free to route client
+        // responses (permission answers) while a turn is in flight. Awaiting a
+        // client request from *inside* a handler would deadlock: the dispatch
+        // loop can't read the response while the handler blocks it.
         .on_receive_request(
             {
                 let state = Arc::clone(&state);
                 async move |req: LoadSessionRequest, responder, cx: ConnectionTo<Client>| {
-                    handle_response(responder, state.handle_load_session(&cx, req).await)
+                    let state = Arc::clone(&state);
+                    let task_cx = cx.clone();
+                    cx.spawn(async move {
+                        let _turn = state.turn_lock.lock().await;
+                        handle_response(responder, state.handle_load_session(&task_cx, req).await)
+                    })
                 }
             },
             agent_client_protocol::on_receive_request!(),
@@ -2690,7 +2869,12 @@ async fn run_acp_server() -> anyhow::Result<()> {
             {
                 let state = Arc::clone(&state);
                 async move |req: ForkSessionRequest, responder, cx: ConnectionTo<Client>| {
-                    handle_response(responder, state.handle_fork_session(&cx, req).await)
+                    let state = Arc::clone(&state);
+                    let task_cx = cx.clone();
+                    cx.spawn(async move {
+                        let _turn = state.turn_lock.lock().await;
+                        handle_response(responder, state.handle_fork_session(&task_cx, req).await)
+                    })
                 }
             },
             agent_client_protocol::on_receive_request!(),
@@ -2699,7 +2883,12 @@ async fn run_acp_server() -> anyhow::Result<()> {
             {
                 let state = Arc::clone(&state);
                 async move |req: NewSessionRequest, responder, cx: ConnectionTo<Client>| {
-                    handle_response(responder, state.handle_new_session(&cx, req).await)
+                    let state = Arc::clone(&state);
+                    let task_cx = cx.clone();
+                    cx.spawn(async move {
+                        let _turn = state.turn_lock.lock().await;
+                        handle_response(responder, state.handle_new_session(&task_cx, req).await)
+                    })
                 }
             },
             agent_client_protocol::on_receive_request!(),
@@ -2708,7 +2897,12 @@ async fn run_acp_server() -> anyhow::Result<()> {
             {
                 let state = Arc::clone(&state);
                 async move |req: PromptRequest, responder, cx: ConnectionTo<Client>| {
-                    handle_response(responder, state.handle_prompt(&cx, req).await)
+                    let state = Arc::clone(&state);
+                    let task_cx = cx.clone();
+                    cx.spawn(async move {
+                        let _turn = state.turn_lock.lock().await;
+                        handle_response(responder, state.handle_prompt(&task_cx, req).await)
+                    })
                 }
             },
             agent_client_protocol::on_receive_request!(),
@@ -2719,10 +2913,15 @@ async fn run_acp_server() -> anyhow::Result<()> {
                 async move |req: SetSessionConfigOptionRequest,
                             responder,
                             cx: ConnectionTo<Client>| {
-                    handle_response(
-                        responder,
-                        state.handle_set_session_config_option(&cx, req).await,
-                    )
+                    let state = Arc::clone(&state);
+                    let task_cx = cx.clone();
+                    cx.spawn(async move {
+                        let _turn = state.turn_lock.lock().await;
+                        handle_response(
+                            responder,
+                            state.handle_set_session_config_option(&task_cx, req).await,
+                        )
+                    })
                 }
             },
             agent_client_protocol::on_receive_request!(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -949,9 +949,10 @@ impl SiGitAgent {
             *guard = Some(args.cwd.clone());
         }
 
-        // A reloaded session starts fresh: grants and plan mode from the
-        // previous life of this session id must not carry over.
-        permissions::reset_session(&args.session_id.to_string());
+        // A session boundary: grants and plan mode from the previous life of
+        // this session id must not carry over — and since one shared engine
+        // means one live conversation, state for every other id is dead too.
+        permissions::reset_all();
 
         // tool calls use relative paths, so we need to match the editor's cwd
         if args.cwd.is_dir()
@@ -988,6 +989,9 @@ impl SiGitAgent {
         args: ForkSessionRequest,
     ) -> agent_client_protocol::Result<ForkSessionResponse> {
         let new_id = SessionId::new(uuid::Uuid::new_v4().to_string());
+        // Session boundary: permission grants and plan mode never cross it
+        // (see handle_load_session), so a fork starts with a clean slate.
+        permissions::reset_all();
         log::info!(
             "fork_session: from={} new={new_id}, cwd={}, additional_directories={:?}",
             args.session_id,
@@ -1035,6 +1039,9 @@ impl SiGitAgent {
         args: NewSessionRequest,
     ) -> agent_client_protocol::Result<NewSessionResponse> {
         let session_id = SessionId::new(uuid::Uuid::new_v4().to_string());
+        // Session boundary: permission grants and plan mode never cross it
+        // (see handle_load_session), so stale ids stop accumulating state.
+        permissions::reset_all();
         log::info!(
             "new_session: id={session_id}, cwd={}, additional_directories={:?}",
             args.cwd.display(),
@@ -2845,6 +2852,29 @@ async fn run_acp_server() -> anyhow::Result<()> {
         model_load_error,
         needs_download,
     ));
+
+    // Honor the explicit provider override (OPENAI_BASE_URL/OPENAI_API_KEY or
+    // an active providers.toml profile) in ACP mode too — the interactive
+    // client already does. Without this the override was silently ignored here
+    // and prompts insisted on a local model. It is also what lets the ACP
+    // integration test drive the agent against a scripted endpoint
+    // (tests/acp_permissions.rs). The model picker still shows the local
+    // selection; overrides are a power-user escape hatch, not a tier.
+    if let Some(cfg) = provider::active_provider() {
+        log::info!(
+            "inference: using {} (model {}) at {}",
+            cfg.display_name,
+            cfg.model,
+            cfg.base_url
+        );
+        let override_backend: Arc<dyn InferenceBackend> = Arc::new(OpenAiBackend::new(
+            cfg.base_url,
+            cfg.api_key,
+            cfg.model,
+            Some(system_prompt_for_model(true).to_string()),
+        ));
+        *state.backend.lock().await = override_backend;
+    }
 
     let stdin = tokio::io::stdin().compat();
     let stdout = tokio::io::stdout().compat_write();

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -1,0 +1,285 @@
+//! Tool permission policy: which agent tools may run, and when to ask.
+//!
+//! Every tool call funnels through one decision point before execution
+//! (`decision_for`). Tools are classified by risk: *read-only* tools (reading
+//! files, searching, listing, fetching a web page) always run, while *mutating*
+//! tools (writing files, deleting, shell commands, MCP tools) are governed by
+//! policy. The policy layers, first match wins:
+//!
+//! 1. **Plan mode** — a per-session switch that denies every mutating tool with
+//!    a message telling the model to present a plan instead. Toggled via
+//!    `/plan on|off` (TUI and ACP).
+//! 2. **Session grants** — "always allow this session", recorded when the user
+//!    picks that option in an approval prompt.
+//! 3. **Per-tool override** — `[permissions.tools]` in `settings.toml`, e.g.
+//!    `run_command = "ask"`, `edit_file = "allow"`, `delete_file = "deny"`.
+//! 4. **Default mode** — `[permissions] default = "ask"|"allow"|"deny"` in
+//!    `settings.toml`; `ask` on a fresh install.
+//!
+//! The `SIGIT_PERMISSIONS` env var (`allow`/`ask`/`deny`) overrides the stored
+//! default without writing the file — the escape hatch for ACP clients that
+//! cannot answer `session/request_permission` and for CI/headless runs.
+//!
+//! Tools discovered from MCP servers (`mcp__*`) and any unknown tool name are
+//! treated as mutating: external tools can have arbitrary side effects, so the
+//! safe assumption is to gate them.
+//!
+//! Session state (grants + plan mode) lives in a process-global keyed by
+//! session id — the same pattern as `mcp.rs`'s server cache — so the ACP
+//! multi-session surface and the single-session TUI share one implementation.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Mutex, OnceLock};
+
+use crate::settings::{self, PermissionMode};
+
+/// Session key used by the interactive TUI, which only ever has one session.
+pub const TUI_SESSION: &str = "tui";
+
+/// How risky a tool is to run without the user's sign-off.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolRisk {
+    /// Observes state without changing it; always allowed to run.
+    ReadOnly,
+    /// Changes files, runs commands, or has unknown side effects; governed by
+    /// the permission policy.
+    Mutating,
+}
+
+/// The outcome of the policy check for one tool call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Decision {
+    /// Run the tool without asking.
+    Allow,
+    /// Ask the user before running (surface-specific: ACP permission request
+    /// or TUI approval prompt).
+    Ask,
+    /// Do not run the tool; the string is returned to the model as the tool
+    /// result so it can adapt instead of retrying blindly.
+    Deny(String),
+}
+
+/// Classify a tool by name. Unknown names and MCP tools are mutating: the
+/// conservative default for anything whose side effects we can't see.
+pub fn classify(tool_name: &str) -> ToolRisk {
+    match tool_name {
+        "read_file" | "list_directory" | "search_files" | "glob" | "read_website"
+        | "write_todos" | "skill" => ToolRisk::ReadOnly,
+        _ => ToolRisk::Mutating,
+    }
+}
+
+/// Per-session permission state.
+#[derive(Default)]
+struct SessionPerms {
+    /// Tools the user chose "always allow this session" for.
+    always_allow: HashSet<String>,
+    /// When set, every mutating tool is denied with a plan-mode message.
+    plan_mode: bool,
+}
+
+fn sessions() -> &'static Mutex<HashMap<String, SessionPerms>> {
+    static SESSIONS: OnceLock<Mutex<HashMap<String, SessionPerms>>> = OnceLock::new();
+    SESSIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn with_session<T>(session: &str, f: impl FnOnce(&mut SessionPerms) -> T) -> T {
+    let mut map = sessions()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    f(map.entry(session.to_string()).or_default())
+}
+
+/// The message returned to the model when a mutating tool is blocked by plan
+/// mode. Instructive rather than terse so the model changes course in one turn.
+fn plan_mode_denial(tool_name: &str) -> String {
+    format!(
+        "Plan mode is active: `{tool_name}` was not executed because it modifies state. \
+         Present a concise plan of the changes you intend to make and ask the user to \
+         approve it (they can run /plan off to enable execution). Read-only tools \
+         (read_file, search_files, glob, list_directory) remain available for research."
+    )
+}
+
+/// The message returned to the model when the user (or policy) denies a tool.
+pub fn user_denial(tool_name: &str) -> String {
+    format!(
+        "The user denied permission to run `{tool_name}`. Do not retry the same call. \
+         Explain what you wanted to do and ask the user how to proceed, or continue \
+         with an approach that does not need this tool."
+    )
+}
+
+/// Policy check for one tool call. See the module docs for the layering.
+pub fn decision_for(session: &str, tool_name: &str) -> Decision {
+    if classify(tool_name) == ToolRisk::ReadOnly {
+        return Decision::Allow;
+    }
+
+    let (plan_mode, granted) = with_session(session, |s| {
+        (s.plan_mode, s.always_allow.contains(tool_name))
+    });
+
+    if plan_mode {
+        return Decision::Deny(plan_mode_denial(tool_name));
+    }
+    if granted {
+        return Decision::Allow;
+    }
+
+    match settings::permission_mode_for(tool_name) {
+        PermissionMode::Allow => Decision::Allow,
+        PermissionMode::Ask => Decision::Ask,
+        PermissionMode::Deny => Decision::Deny(format!(
+            "`{tool_name}` is denied by the permission policy in settings.toml. \
+             Do not retry it; work without this tool or ask the user to change \
+             the policy."
+        )),
+    }
+}
+
+/// Record an "always allow this session" grant for a tool.
+pub fn grant_for_session(session: &str, tool_name: &str) {
+    with_session(session, |s| {
+        s.always_allow.insert(tool_name.to_string());
+    });
+}
+
+/// Toggle plan mode for a session. Returns the new state.
+pub fn set_plan_mode(session: &str, enabled: bool) -> bool {
+    with_session(session, |s| {
+        s.plan_mode = enabled;
+        s.plan_mode
+    })
+}
+
+/// Whether plan mode is active for a session.
+pub fn plan_mode(session: &str) -> bool {
+    with_session(session, |s| s.plan_mode)
+}
+
+/// Drop all recorded state for a session (fresh session, /clear, or session
+/// teardown) so grants never outlive the conversation they were given in.
+pub fn reset_session(session: &str) {
+    let mut map = sessions()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    map.remove(session);
+}
+
+/// One-line status summary for `/permissions` and `/status`.
+pub fn describe(session: &str) -> String {
+    let plan = if plan_mode(session) { "on" } else { "off" };
+    let default = settings::permission_default();
+    let granted = with_session(session, |s| {
+        let mut names: Vec<&str> = s.always_allow.iter().map(String::as_str).collect();
+        names.sort_unstable();
+        names.join(", ")
+    });
+    let granted = if granted.is_empty() {
+        "none".to_string()
+    } else {
+        granted
+    };
+    format!(
+        "permissions: default={default} | plan mode: {plan} | session grants: {granted}\n\
+         read-only tools always run; configure [permissions] in settings.toml"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `decision_for` reads settings (env + file), and the settings test
+    /// mutates `SIGIT_CONFIG_DIR`/`SIGIT_PERMISSIONS` under this lock — hold it
+    /// here too so parallel test runs don't race, and point the config dir at
+    /// an empty sandbox so a developer's real settings.toml can't skew results.
+    fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+        let guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let dir = std::env::temp_dir().join(format!("sigit_perm_tests_{}", std::process::id()));
+        // SAFETY: process-global env mutation, serialized by ENV_TEST_LOCK; the
+        // other env-touching tests re-set these before reading.
+        unsafe { std::env::set_var("SIGIT_CONFIG_DIR", &dir) };
+        unsafe { std::env::remove_var("SIGIT_PERMISSIONS") };
+        guard
+    }
+
+    #[test]
+    fn read_only_tools_always_allowed() {
+        let _guard = env_guard();
+        for tool in [
+            "read_file",
+            "list_directory",
+            "search_files",
+            "glob",
+            "read_website",
+            "write_todos",
+            "skill",
+        ] {
+            assert_eq!(classify(tool), ToolRisk::ReadOnly, "{tool}");
+            assert_eq!(decision_for("t-ro", tool), Decision::Allow, "{tool}");
+        }
+    }
+
+    #[test]
+    fn mutating_and_unknown_tools_are_gated() {
+        for tool in [
+            "edit_file",
+            "multi_edit",
+            "create_file",
+            "create_directory",
+            "delete_file",
+            "run_command",
+            "remember",
+            "mcp__server__anything",
+            "totally_unknown_tool",
+        ] {
+            assert_eq!(classify(tool), ToolRisk::Mutating, "{tool}");
+        }
+    }
+
+    #[test]
+    fn plan_mode_denies_mutating_and_spares_read_only() {
+        let _guard = env_guard();
+        let session = "t-plan";
+        reset_session(session);
+        set_plan_mode(session, true);
+        assert!(matches!(
+            decision_for(session, "run_command"),
+            Decision::Deny(_)
+        ));
+        assert_eq!(decision_for(session, "read_file"), Decision::Allow);
+        set_plan_mode(session, false);
+        reset_session(session);
+    }
+
+    #[test]
+    fn session_grant_short_circuits_ask() {
+        let _guard = env_guard();
+        let session = "t-grant";
+        reset_session(session);
+        grant_for_session(session, "edit_file");
+        assert_eq!(decision_for(session, "edit_file"), Decision::Allow);
+        // Other tools are unaffected by the grant.
+        assert_ne!(decision_for(session, "delete_file"), Decision::Allow);
+        reset_session(session);
+        assert_ne!(decision_for(session, "edit_file"), Decision::Allow);
+    }
+
+    #[test]
+    fn plan_mode_outranks_session_grant() {
+        let _guard = env_guard();
+        let session = "t-rank";
+        reset_session(session);
+        grant_for_session(session, "edit_file");
+        set_plan_mode(session, true);
+        assert!(matches!(
+            decision_for(session, "edit_file"),
+            Decision::Deny(_)
+        ));
+        reset_session(session);
+    }
+}

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -184,6 +184,18 @@ pub fn reset_session(session: &str) {
     map.remove(session);
 }
 
+/// Drop the recorded state for *every* session. Called at ACP session
+/// boundaries (new/load/fork): the agent drives one shared engine, so only one
+/// conversation is live at a time and grants must never cross a boundary. This
+/// also keeps the map from accumulating entries for session ids that will
+/// never be used again.
+pub fn reset_all() {
+    let mut map = sessions()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    map.clear();
+}
+
 /// One-line status summary for `/permissions` and `/status`.
 pub fn describe(session: &str) -> String {
     let plan = if plan_mode(session) { "on" } else { "off" };

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -113,6 +113,20 @@ pub fn user_denial(tool_name: &str) -> String {
     )
 }
 
+/// Render a tool call's arguments for an approval prompt. The person deciding
+/// must be able to see what they are approving, so the cap is generous and any
+/// cut is marked with how much is hidden — silently truncating could hide the
+/// tail of a command from the user who is about to allow it.
+pub fn approval_preview(arguments: &str) -> String {
+    const MAX_CHARS: usize = 500;
+    let total = arguments.chars().count();
+    if total <= MAX_CHARS {
+        return arguments.to_string();
+    }
+    let shown: String = arguments.chars().take(MAX_CHARS).collect();
+    format!("{shown}… [+{} more chars]", total - MAX_CHARS)
+}
+
 /// Policy check for one tool call. See the module docs for the layering.
 pub fn decision_for(session: &str, tool_name: &str) -> Decision {
     if classify(tool_name) == ToolRisk::ReadOnly {
@@ -270,6 +284,23 @@ mod tests {
         assert_ne!(decision_for(session, "delete_file"), Decision::Allow);
         reset_session(session);
         assert_ne!(decision_for(session, "edit_file"), Decision::Allow);
+    }
+
+    #[test]
+    fn approval_preview_shows_short_arguments_in_full() {
+        let args = r#"{"command":"cargo test"}"#;
+        assert_eq!(approval_preview(args), args);
+    }
+
+    #[test]
+    fn approval_preview_marks_truncation_explicitly() {
+        let args = format!(r#"{{"command":"echo {}; rm -rf /"}}"#, "x".repeat(600));
+        let preview = approval_preview(&args);
+        assert!(preview.chars().count() < args.chars().count());
+        assert!(
+            preview.contains("more chars]"),
+            "hidden content must be flagged, got: {preview}"
+        );
     }
 
     #[test]

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -34,6 +34,9 @@ use std::sync::{Mutex, OnceLock};
 use crate::settings::{self, PermissionMode};
 
 /// Session key used by the interactive TUI, which only ever has one session.
+/// The TUI (`chat.rs`) is `#[cfg(unix)]`, so this is its only consumer and is
+/// dead on non-Unix targets — the rest of the module is used on all platforms.
+#[cfg_attr(not(unix), allow(dead_code))]
 pub const TUI_SESSION: &str = "tui";
 
 /// How risky a tool is to run without the user's sign-off.

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -8,11 +8,11 @@
 //!    endpoint and tier are built in, and the session token is the credential.
 //! 3. On-device: no login and no override, so inference runs locally.
 //!
-//! Provider resolution is consumed only by the interactive client, which is
-//! `#[cfg(unix)]`. The display helpers (`cloud_tier_label`, `CLOUD_TIERS`) are
-//! still used cross-platform by `/models`, but the resolution path is dead on
-//! non-Unix targets, where the binary runs ACP-only and on-device. Suppress the
-//! dead-code lint there only — Unix builds keep full coverage.
+//! Provider resolution runs at startup in both modes: the interactive client
+//! picks its whole backend from it, and `run_acp_server` applies the explicit
+//! override (env or `providers.toml`) the same way. Some items are still wired
+//! up only through `#[cfg(unix)]` interactive paths, so the dead-code lint
+//! stays suppressed on non-Unix targets only — Unix builds keep full coverage.
 #![cfg_attr(not(unix), allow(dead_code))]
 
 use std::path::PathBuf;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -5,12 +5,14 @@
 //! [`crate::credentials`] but holds preferences rather than secrets, so it is
 //! not permission-restricted.
 //!
-//! The only setting today is `local_inference`: whether on-device inference is
-//! the active mode. It is the source of truth for the local/cloud toggle and
-//! drives how `/models` presents the picker. It is stored locally so the toggle
-//! works even on ACP clients that do not support slash commands (e.g. Xcode),
-//! where it is also surfaced as a session config option.
+//! Settings today: `local_inference` (whether on-device inference is the
+//! active mode — the source of truth for the local/cloud toggle, also surfaced
+//! as a session config option for ACP clients without slash commands, e.g.
+//! Xcode) and `[permissions]` (the tool permission policy consumed by
+//! `crate::permissions`: a default mode for mutating tools plus per-tool
+//! overrides).
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -20,8 +22,71 @@ use serde::{Deserialize, Serialize};
 /// style); it never writes the file.
 const LOCAL_INFERENCE_ENV: &str = "SIGIT_LOCAL_INFERENCE";
 
+/// Env override for the default permission mode (`allow`/`ask`/`deny`). Wins
+/// over the stored default (but not over per-tool overrides); never writes the
+/// file. The escape hatch for ACP clients that cannot answer permission
+/// requests and for headless runs.
+const PERMISSIONS_ENV: &str = "SIGIT_PERMISSIONS";
+
 fn default_local_inference() -> bool {
     true
+}
+
+/// What to do when the model calls a mutating tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum PermissionMode {
+    /// Run without asking.
+    Allow,
+    /// Ask the user first (ACP permission request / TUI approval prompt).
+    #[default]
+    Ask,
+    /// Never run; the model gets an explanatory tool result.
+    Deny,
+}
+
+impl PermissionMode {
+    fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "allow" => Some(Self::Allow),
+            "ask" => Some(Self::Ask),
+            "deny" => Some(Self::Deny),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for PermissionMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Allow => "allow",
+            Self::Ask => "ask",
+            Self::Deny => "deny",
+        })
+    }
+}
+
+/// The `[permissions]` table: a default mode for mutating tools plus per-tool
+/// overrides, e.g.
+///
+/// ```toml
+/// [permissions]
+/// default = "ask"
+///
+/// [permissions.tools]
+/// edit_file = "allow"
+/// delete_file = "deny"
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct PermissionSettings {
+    /// Mode for mutating tools without a per-tool override. `ask` on a fresh
+    /// install.
+    #[serde(default)]
+    pub default: PermissionMode,
+    /// Per-tool overrides by tool name (MCP tools use their full
+    /// `mcp__<server>__<tool>` name).
+    #[serde(default)]
+    pub tools: BTreeMap<String, PermissionMode>,
 }
 
 /// Persisted preferences. New fields must carry `#[serde(default)]` so older
@@ -32,12 +97,16 @@ pub struct Settings {
     /// fresh install.
     #[serde(default = "default_local_inference")]
     pub local_inference: bool,
+    /// Permission policy for mutating agent tools.
+    #[serde(default)]
+    pub permissions: PermissionSettings,
 }
 
 impl Default for Settings {
     fn default() -> Self {
         Self {
             local_inference: default_local_inference(),
+            permissions: PermissionSettings::default(),
         }
     }
 }
@@ -108,6 +177,32 @@ pub fn set_local_inference(enabled: bool) -> Result<(), String> {
     store(&settings)
 }
 
+/// The default permission mode for mutating tools: the `SIGIT_PERMISSIONS` env
+/// var when set to a recognized mode, else the stored `[permissions] default`.
+pub fn permission_default() -> PermissionMode {
+    if let Ok(raw) = std::env::var(PERMISSIONS_ENV)
+        && let Some(mode) = PermissionMode::parse(&raw)
+    {
+        return mode;
+    }
+    load().permissions.default
+}
+
+/// The effective permission mode for one tool: its `[permissions.tools]`
+/// override when present, else the default (see [`permission_default`]).
+pub fn permission_mode_for(tool_name: &str) -> PermissionMode {
+    let settings = load();
+    if let Some(mode) = settings.permissions.tools.get(tool_name) {
+        return *mode;
+    }
+    if let Ok(raw) = std::env::var(PERMISSIONS_ENV)
+        && let Some(mode) = PermissionMode::parse(&raw)
+    {
+        return mode;
+    }
+    settings.permissions.default
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -146,6 +241,40 @@ mod tests {
             "unrecognized env value falls back to stored setting"
         );
 
+        // Permissions: fresh install asks; per-tool overrides win over the
+        // default; the env var overrides the stored default but not per-tool
+        // overrides.
+        unsafe { std::env::remove_var(PERMISSIONS_ENV) };
+        assert_eq!(permission_default(), PermissionMode::Ask);
+        assert_eq!(permission_mode_for("run_command"), PermissionMode::Ask);
+
+        let mut settings = load();
+        settings.permissions.default = PermissionMode::Allow;
+        settings
+            .permissions
+            .tools
+            .insert("delete_file".to_string(), PermissionMode::Deny);
+        store(&settings).unwrap();
+        assert_eq!(permission_default(), PermissionMode::Allow);
+        assert_eq!(permission_mode_for("run_command"), PermissionMode::Allow);
+        assert_eq!(permission_mode_for("delete_file"), PermissionMode::Deny);
+
+        unsafe { std::env::set_var(PERMISSIONS_ENV, "deny") };
+        assert_eq!(permission_default(), PermissionMode::Deny);
+        assert_eq!(permission_mode_for("run_command"), PermissionMode::Deny);
+        assert_eq!(
+            permission_mode_for("delete_file"),
+            PermissionMode::Deny,
+            "per-tool override still wins"
+        );
+        unsafe { std::env::set_var(PERMISSIONS_ENV, "garbage") };
+        assert_eq!(
+            permission_default(),
+            PermissionMode::Allow,
+            "unrecognized env value falls back to stored setting"
+        );
+
+        unsafe { std::env::remove_var(PERMISSIONS_ENV) };
         unsafe { std::env::remove_var(LOCAL_INFERENCE_ENV) };
         unsafe { std::env::remove_var("SIGIT_CONFIG_DIR") };
         let _ = std::fs::remove_dir_all(&dir);

--- a/tests/acp_permissions.rs
+++ b/tests/acp_permissions.rs
@@ -1,0 +1,353 @@
+//! End-to-end ACP permission round-trip against the real binary.
+//!
+//! Spawns `sigit` in ACP mode (stdin piped, so not a TTY) wired to a scripted
+//! OpenAI-compatible SSE endpoint via the `OPENAI_BASE_URL` override, then
+//! drives newline-delimited JSON-RPC over stdio. The scripted model calls
+//! `run_command` — a mutating tool — so the agent must send
+//! `session/request_permission` mid-turn (the exact path the spawned-handler /
+//! `turn_lock` design exists for). The test answers it twice:
+//!
+//! 1. `cancelled` — the prompt must stop with `stopReason: "cancelled"`, and
+//!    the *next* request to the endpoint must show the abandoned round closed
+//!    out with `role: "tool"` results, or a strict OpenAI-compatible endpoint
+//!    would reject the whole session.
+//! 2. `selected: allow_once` — the tool must actually execute and its output
+//!    travel back to the endpoint as a tool result.
+
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpListener;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{Receiver, channel};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+const TIMEOUT: Duration = Duration::from_secs(60);
+
+// ── Scripted OpenAI-compatible endpoint ─────────────────────────────────────
+
+fn sse_body(events: &[Value]) -> String {
+    let mut body = String::new();
+    for event in events {
+        body.push_str("data: ");
+        body.push_str(&event.to_string());
+        body.push_str("\n\n");
+    }
+    body.push_str("data: [DONE]\n\n");
+    body
+}
+
+fn sse_tool_call(id: &str, name: &str, arguments: &str) -> String {
+    sse_body(&[json!({
+        "choices": [{"delta": {"tool_calls": [{
+            "index": 0,
+            "id": id,
+            "function": {"name": name, "arguments": arguments},
+        }]}}]
+    })])
+}
+
+fn sse_text(text: &str) -> String {
+    sse_body(&[json!({"choices": [{"delta": {"content": text}}]})])
+}
+
+/// Serves one scripted SSE response per request and records each request body.
+struct FakeEndpoint {
+    port: u16,
+    requests: Arc<Mutex<Vec<Value>>>,
+}
+
+fn start_fake_endpoint(responses: Vec<String>) -> FakeEndpoint {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake endpoint");
+    let port = listener.local_addr().unwrap().port();
+    let requests: Arc<Mutex<Vec<Value>>> = Arc::default();
+    let recorded = Arc::clone(&requests);
+    let queue = Mutex::new(VecDeque::from(responses));
+
+    std::thread::spawn(move || {
+        // `connection: close` below means one request per connection, so the
+        // serial accept loop matches the agent's serial completion requests.
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            let mut reader = BufReader::new(match stream.try_clone() {
+                Ok(clone) => clone,
+                Err(_) => continue,
+            });
+            let mut content_length = 0usize;
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    break;
+                }
+                let line = line.trim();
+                if line.is_empty() {
+                    break;
+                }
+                if let Some(length) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                    content_length = length.trim().parse().unwrap_or(0);
+                }
+            }
+            let mut body = vec![0u8; content_length];
+            if reader.read_exact(&mut body).is_err() {
+                continue;
+            }
+            if let Ok(request) = serde_json::from_slice::<Value>(&body) {
+                recorded.lock().unwrap().push(request);
+            }
+            let payload = queue
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| sse_text("out of scripted responses"));
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\n\
+                 content-length: {}\r\nconnection: close\r\n\r\n{}",
+                payload.len(),
+                payload
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+
+    FakeEndpoint { port, requests }
+}
+
+// ── ACP client over the binary's stdio ──────────────────────────────────────
+
+struct AgentUnderTest {
+    child: Child,
+    stdin: ChildStdin,
+    incoming: Receiver<Value>,
+    next_id: u64,
+}
+
+fn spawn_agent(port: u16, config_dir: &std::path::Path) -> AgentUnderTest {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_sigit"))
+        .env("OPENAI_BASE_URL", format!("http://127.0.0.1:{port}"))
+        .env("OPENAI_API_KEY", "test-key")
+        .env("SIGIT_MODEL", "scripted-model")
+        .env("SIGIT_CONFIG_DIR", config_dir)
+        .env("SIGIT_MCP", "off")
+        // A fresh config dir means the default permission mode, `ask` — make
+        // sure the environment can't turn the gate off underneath the test.
+        .env_remove("SIGIT_PERMISSIONS")
+        .env_remove("SIGIT_LOCAL_INFERENCE")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sigit in ACP mode");
+
+    let stdout = child.stdout.take().unwrap();
+    let (message_tx, incoming) = channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let Ok(line) = line else { break };
+            if let Ok(message) = serde_json::from_str::<Value>(&line)
+                && message_tx.send(message).is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    let stdin = child.stdin.take().unwrap();
+    AgentUnderTest {
+        child,
+        stdin,
+        incoming,
+        next_id: 0,
+    }
+}
+
+impl AgentUnderTest {
+    fn send(&mut self, message: Value) {
+        let mut line = message.to_string();
+        line.push('\n');
+        self.stdin
+            .write_all(line.as_bytes())
+            .expect("write to agent stdin");
+        self.stdin.flush().expect("flush agent stdin");
+    }
+
+    fn request(&mut self, method: &str, params: Value) -> u64 {
+        self.next_id += 1;
+        let id = self.next_id;
+        self.send(json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params}));
+        id
+    }
+
+    fn respond(&mut self, id: Value, result: Value) {
+        self.send(json!({"jsonrpc": "2.0", "id": id, "result": result}));
+    }
+
+    /// Skip notifications and unrelated traffic until `matches` is satisfied.
+    fn wait_for(&mut self, what: &str, matches: impl Fn(&Value) -> bool) -> Value {
+        let deadline = Instant::now() + TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            match self.incoming.recv_timeout(remaining) {
+                Ok(message) if matches(&message) => return message,
+                Ok(_) => continue,
+                Err(_) => panic!("timed out waiting for {what}"),
+            }
+        }
+    }
+
+    /// The response to one of *our* requests (has our id, no `method`).
+    fn wait_for_response(&mut self, id: u64) -> Value {
+        let response = self.wait_for(&format!("response to request {id}"), |message| {
+            message["id"] == id && message.get("method").is_none()
+        });
+        assert!(
+            response.get("error").is_none(),
+            "request {id} failed: {response}"
+        );
+        response
+    }
+
+    /// A request *from* the agent (has a `method` and its own id).
+    fn wait_for_agent_request(&mut self, method: &str) -> Value {
+        self.wait_for(&format!("agent request {method}"), |message| {
+            message["method"] == method && message.get("id").is_some()
+        })
+    }
+}
+
+impl Drop for AgentUnderTest {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+// ── The round-trip ──────────────────────────────────────────────────────────
+
+#[test]
+fn permission_round_trip_cancel_then_allow() {
+    let endpoint = start_fake_endpoint(vec![
+        sse_tool_call("call_1", "run_command", r#"{"command":"echo sigit-first"}"#),
+        sse_tool_call(
+            "call_2",
+            "run_command",
+            r#"{"command":"echo sigit-approved"}"#,
+        ),
+        sse_text("done"),
+    ]);
+
+    let scratch = std::env::temp_dir().join(format!("sigit_acp_perm_{}", std::process::id()));
+    let config_dir = scratch.join("config");
+    let cwd = scratch.join("cwd");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    let mut agent = spawn_agent(endpoint.port, &config_dir);
+
+    let id = agent.request(
+        "initialize",
+        json!({"protocolVersion": 1, "clientCapabilities": {}}),
+    );
+    agent.wait_for_response(id);
+
+    let id = agent.request("session/new", json!({"cwd": cwd, "mcpServers": []}));
+    let session_id = agent.wait_for_response(id)["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    // ── Turn 1: cancel at the permission gate ───────────────────────────
+    let prompt_id = agent.request(
+        "session/prompt",
+        json!({
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": "run the first command"}],
+        }),
+    );
+
+    let permission = agent.wait_for_agent_request("session/request_permission");
+    let params = &permission["params"];
+    assert_eq!(params["sessionId"], session_id.as_str());
+    let title = params["toolCall"]["title"].as_str().expect("title");
+    assert!(
+        title.contains("run_command") && title.contains("echo sigit-first"),
+        "the dialog must show the tool and its arguments, got: {title}"
+    );
+    assert_eq!(
+        params["toolCall"]["rawInput"]["command"], "echo sigit-first",
+        "full arguments must travel as rawInput"
+    );
+    let option_ids: Vec<&str> = params["options"]
+        .as_array()
+        .expect("options")
+        .iter()
+        .map(|option| option["optionId"].as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(option_ids, ["allow_once", "allow_session", "reject_once"]);
+
+    agent.respond(
+        permission["id"].clone(),
+        json!({"outcome": {"outcome": "cancelled"}}),
+    );
+
+    let response = agent.wait_for_response(prompt_id);
+    assert_eq!(response["result"]["stopReason"], "cancelled");
+
+    // ── Turn 2: history must be repaired; then approve once ─────────────
+    let prompt_id = agent.request(
+        "session/prompt",
+        json!({
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": "run the second command"}],
+        }),
+    );
+
+    let permission = agent.wait_for_agent_request("session/request_permission");
+    agent.respond(
+        permission["id"].clone(),
+        json!({"outcome": {"outcome": "selected", "optionId": "allow_once"}}),
+    );
+
+    let response = agent.wait_for_response(prompt_id);
+    assert_eq!(response["result"]["stopReason"], "end_turn");
+
+    // ── What the endpoint saw ────────────────────────────────────────────
+    let requests = endpoint.requests.lock().unwrap();
+    assert_eq!(requests.len(), 3, "expected exactly three completions");
+
+    // Request 2 replays the full history: the cancelled round's tool call
+    // must be answered by a `role: "tool"` message, not left dangling.
+    let messages = requests[1]["messages"].as_array().expect("messages");
+    let call_position = messages
+        .iter()
+        .position(|message| message["tool_calls"][0]["id"] == "call_1")
+        .expect("cancelled turn's assistant tool call in replayed history");
+    let repair = &messages[call_position + 1];
+    assert_eq!(repair["role"], "tool", "dangling tool call not closed out");
+    assert_eq!(repair["tool_call_id"], "call_1");
+    assert!(
+        repair["content"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("cancelled"),
+        "repair message should say the turn was cancelled: {repair}"
+    );
+
+    // Request 3 carries the approved call's real output.
+    let messages = requests[2]["messages"].as_array().expect("messages");
+    let result = messages
+        .iter()
+        .find(|message| message["role"] == "tool" && message["tool_call_id"] == "call_2")
+        .expect("tool result for the approved call");
+    assert!(
+        result["content"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("sigit-approved"),
+        "the approved command's output should reach the endpoint: {result}"
+    );
+
+    drop(agent);
+    let _ = std::fs::remove_dir_all(&scratch);
+}


### PR DESCRIPTION
## What this does

Until now siGit ran whatever tool the model asked for — edits, shell commands, file deletes, and (since MCP landed) any external MCP tool — with no chance for the user to step in. This adds a permission layer so the agent asks before it touches anything.

Read-only tools (reading, searching, globbing, listing, fetching a page, writing todos) still run freely — there's nothing to approve. Everything that changes state goes through a gate first.

## How a call gets decided

When the model calls a mutating tool, the policy is checked in order, first match wins:

1. **Plan mode** — after `/plan on`, mutating tools are blocked and the model is told to lay out a plan instead. Handy for "look before you leap" work: it can still read and search all it wants.
2. **Session grants** — if you already picked "always allow for this session" for that tool, it just runs.
3. **Your settings** — `[permissions]` in `settings.toml` sets a default (`allow`/`ask`/`deny`) plus per-tool overrides, e.g. `run_command = "ask"`, `edit_file = "allow"`. Fresh installs default to `ask`.

MCP tools and anything we don't recognize count as mutating — the safe assumption for side effects we can't see. `SIGIT_PERMISSIONS` is an escape hatch for headless/CI runs and clients that can't show a prompt.

## What it feels like

- **In editors (ACP):** on `ask`, siGit sends a standard `session/request_permission`, so Zed and friends show their own native dialog — Allow once · Allow for this session · Deny.
- **In the terminal (TUI):** the agent pauses and the footer asks `allow run_command? [y]es · [a]lways · [n]o`. Ctrl+C cancels the whole turn.

Either way a denial comes back to the model as a plain-English note, so it adapts instead of hammering the same call.

Both surfaces get `/plan [on|off]` and `/permissions` (prints the current policy). `/clear` and reloading a session wipe the per-session grants and plan flag so nothing leaks between conversations.

## One gotcha worth flagging

The ACP SDK runs on a single dispatch loop — if a request handler blocks waiting for a reply, nothing else moves, including the permission answer we're waiting on. So the prompt/session/config handlers now run in spawned tasks serialized by a `turn_lock`: same ordering as before, but the loop stays free to route the client's answer mid-turn. It also sets up real mid-turn cancellation down the line.

## Testing

- `cargo fmt`, `clippy -D warnings`, and the full suite (104 tests) pass locally on the CI toolchain (1.96) for the Linux target.
- A scripted ACP smoke test drives the real binary over stdio (`initialize → session/new → /permissions → /plan on`) to prove the spawned-handler change doesn't deadlock a client.
- One cross-platform gotcha: `TUI_SESSION` is only used by the Unix-only TUI, so the Windows Clippy job tripped `-D dead-code`. Fixed by gating it on `cfg(unix)` (the same pattern `backend.rs`/`provider.rs` already use); the Windows runner is the source of truth for that one, since the target can't be fully built here.

Stacked on the tools work that shipped in v1.3.1; this branch now sits directly on `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)