### PR TITLE
Fix headless build after permission rules signature change

### DIFF
--- a/src/headless.rs
+++ b/src/headless.rs
@@ -144,7 +144,7 @@ pub async fn run(config: HeadlessConfig) -> i32 {
     // Fresh permission state for the run, then apply the flag grants.
     permissions::reset_session(HEADLESS_SESSION);
     for tool in &config.allow_tools {
-        permissions::grant_for_session(HEADLESS_SESSION, tool);
+        permissions::grant_for_session(HEADLESS_SESSION, tool, "");
     }
     let denied: HashSet<&str> = config.deny_tools.iter().map(String::as_str).collect();
 
@@ -269,7 +269,7 @@ async fn run_prompt(
                 log::info!("headless: {} blocked by --deny-tool", tc.name);
                 deny_flag_denial(&tc.name)
             } else {
-                match permissions::decision_for(HEADLESS_SESSION, &tc.name) {
+                match permissions::decision_for(HEADLESS_SESSION, &tc.name, &tc.arguments) {
                     permissions::Decision::Allow => {
                         tools::execute_tool(&tc.name, &tc.arguments).await
                     }


### PR DESCRIPTION
PR #27 (headless mode) and PR #28 (permission rule patterns) were developed in parallel. #28 added an `arguments` parameter to `decision_for` and `grant_for_session`, and merging it after #27 left the two call sites in `headless.rs` on the old signatures. `cargo clippy --tests` no longer compiles on `development`, so every branch cut from it fails the CI gate.

The fix matches the TUI call site in `chat.rs`: pass the tool call's raw arguments to `decision_for`, and an empty string for `--allow-tool` grants. An empty argument string makes `session_grant_rule` fall back to the bare tool name, which is the whole-tool grant the flag intends.

Full local gate is green: fmt, clippy with `-D warnings`, and `cargo test --locked` (172 tests, including the three headless_mode tests that cover both call sites).