### PR TITLE
fix(docs): trust the Homebrew tap with brew trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cargo install sigit
 
 | Method | Command |
 |--------|---------|
-| Homebrew | `brew tap --force-auto-update getsigit/tap && brew install sigit` |
+| Homebrew | `brew tap --force getsigit/tap && brew install sigit` |
 | pip | `pip install sigit-code` |
 | uv | `uvx --from sigit-code sigit` |
 | npm | `npm install -g @smbcloud/sigit` |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cargo install sigit
 
 | Method | Command |
 |--------|---------|
-| Homebrew | `brew tap getsigit/tap && brew install sigit` |
+| Homebrew | `brew tap --force-auto-update getsigit/tap && brew install sigit` |
 | pip | `pip install sigit-code` |
 | uv | `uvx --from sigit-code sigit` |
 | npm | `npm install -g @smbcloud/sigit` |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cargo install sigit
 
 | Method | Command |
 |--------|---------|
-| Homebrew | `brew tap --force getsigit/tap && brew install sigit` |
+| Homebrew | `brew tap getsigit/tap && brew trust --tap getsigit/tap && brew install sigit` |
 | pip | `pip install sigit-code` |
 | uv | `uvx --from sigit-code sigit` |
 | npm | `npm install -g @smbcloud/sigit` |

--- a/npm/README.md.tmpl
+++ b/npm/README.md.tmpl
@@ -28,7 +28,7 @@ npm install -g @smbcloud/sigit
 | Channel | Command |
 |---------|---------|
 | npm | `npm install -g @smbcloud/sigit` |
-| Homebrew | `brew tap getsigit/tap && brew install sigit` |
+| Homebrew | `brew tap getsigit/tap && brew trust --tap getsigit/tap && brew install sigit` |
 | pip | `pip install sigit-code` |
 | uv | `uvx --from sigit-code sigit` |
 | Cargo | `cargo install sigit` |

--- a/npm/sigit/README.md
+++ b/npm/sigit/README.md
@@ -31,7 +31,7 @@ Supported targets:
 
 | Method | Command |
 |---|---|
-| Homebrew | `brew tap --force-auto-update getsigit/tap && brew install sigit` |
+| Homebrew | `brew tap --force getsigit/tap && brew install sigit` |
 | pip | `pip install sigit-code` |
 | uv | `uvx --from sigit-code sigit` |
 | Cargo | `cargo install sigit` |

--- a/npm/sigit/README.md
+++ b/npm/sigit/README.md
@@ -31,7 +31,7 @@ Supported targets:
 
 | Method | Command |
 |---|---|
-| Homebrew | `brew tap getsigit/tap && brew install sigit` |
+| Homebrew | `brew tap --force-auto-update getsigit/tap && brew install sigit` |
 | pip | `pip install sigit-code` |
 | uv | `uvx --from sigit-code sigit` |
 | Cargo | `cargo install sigit` |

--- a/npm/sigit/README.md
+++ b/npm/sigit/README.md
@@ -31,7 +31,7 @@ Supported targets:
 
 | Method | Command |
 |---|---|
-| Homebrew | `brew tap --force getsigit/tap && brew install sigit` |
+| Homebrew | `brew tap getsigit/tap && brew trust --tap getsigit/tap && brew install sigit` |
 | pip | `pip install sigit-code` |
 | uv | `uvx --from sigit-code sigit` |
 | Cargo | `cargo install sigit` |

--- a/pypi/README.md
+++ b/pypi/README.md
@@ -54,7 +54,7 @@ Then pick **siGit Code** in the assistant panel.
 | Method | Command |
 |--------|---------|
 | npm | `npm install -g @smbcloud/sigit` |
-| Homebrew | `brew tap --force-auto-update getsigit/tap && brew install sigit` |
+| Homebrew | `brew tap --force getsigit/tap && brew install sigit` |
 | Cargo | `cargo install sigit` |
 
 ### From source

--- a/pypi/README.md
+++ b/pypi/README.md
@@ -54,7 +54,7 @@ Then pick **siGit Code** in the assistant panel.
 | Method | Command |
 |--------|---------|
 | npm | `npm install -g @smbcloud/sigit` |
-| Homebrew | `brew tap getsigit/tap && brew install sigit` |
+| Homebrew | `brew tap --force-auto-update getsigit/tap && brew install sigit` |
 | Cargo | `cargo install sigit` |
 
 ### From source

--- a/pypi/README.md
+++ b/pypi/README.md
@@ -54,7 +54,7 @@ Then pick **siGit Code** in the assistant panel.
 | Method | Command |
 |--------|---------|
 | npm | `npm install -g @smbcloud/sigit` |
-| Homebrew | `brew tap --force getsigit/tap && brew install sigit` |
+| Homebrew | `brew tap getsigit/tap && brew trust --tap getsigit/tap && brew install sigit` |
 | Cargo | `cargo install sigit` |
 
 ### From source


### PR DESCRIPTION
## What

Fixes the Homebrew install command across all READMEs so the tap is trusted before install:

```
brew tap getsigit/tap && brew trust --tap getsigit/tap && brew install sigit
```

Applied to `README.md`, `pypi/README.md`, `npm/sigit/README.md`, and the source template `npm/README.md.tmpl` (so the generated npm README doesn't revert on the next release).

## Why

On fresh installs users hit Homebrew 6.x's untrusted-tap error:

```
Error: Refusing to load formula getsigit/tap/sigit from untrusted tap getsigit/tap.
```

The trust is cleared by `brew trust --tap getsigit/tap`, which records the tap in Homebrew's `trust.json`. Earlier attempts in this branch used `brew tap --force-auto-update` and `brew tap --force`; neither affects trust — `--force-auto-update` isn't a real flag and `--force` only forces core taps under API mode, so the install kept failing with the same error.