### PR TITLE
fix: use noreply address for siGit Code co-author trailer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -144,7 +144,7 @@ Git operations — always use run_command:
 - if a clone or init fails, check the error, fix the cause (wrong path, missing \
   directory, permissions), and retry
 - when you create a commit, always end the commit message with a blank line and \
-  then this trailer on its own line: Co-Authored-By: siGit Code <sigit@sigit.si> \
+  then this trailer on its own line: Co-Authored-By: siGit Code <297239231+sigitc@users.noreply.github.com> \
   — GitHub reads that exact format and credits siGit as co-author. If a commit \
   lands without it, siGit Code amends the trailer in automatically and the tool \
   output says so; do not amend again yourself.

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1671,12 +1671,13 @@ fn spawn_shell(command_str: &str, cwd_path: &Path) -> std::io::Result<std::proce
 /// Trailer identifying siGit Code as the co-author of commits it creates.
 /// GitHub detects `Co-authored-by:` trailers on the last lines of a commit
 /// message (separated from the body by a blank line) and lists the agent
-/// alongside the human author; `sigit@sigit.si` belongs to the
-/// <https://github.com/sigitc> account ("siGit Code"), so the co-author is
-/// rendered with that account's avatar and profile link. The system prompt
-/// asks the model to add this itself; [`ensure_commit_co_author`] is the
-/// safety net when it forgets.
-pub const COMMIT_CO_AUTHOR_TRAILER: &str = "Co-Authored-By: siGit Code <sigit@sigit.si>";
+/// alongside the human author; `297239231+sigitc@users.noreply.github.com`
+/// is the noreply address for the <https://github.com/sigitc> account
+/// ("siGit Code"), so the co-author is rendered with that account's avatar
+/// and profile link. The system prompt asks the model to add this itself;
+/// [`ensure_commit_co_author`] is the safety net when it forgets.
+pub const COMMIT_CO_AUTHOR_TRAILER: &str =
+    "Co-Authored-By: siGit Code <297239231+sigitc@users.noreply.github.com>";
 
 /// Run `git <args>` in `cwd`, returning trimmed stdout on success.
 fn git_stdout(cwd: &Path, args: &[&str]) -> Option<String> {


### PR DESCRIPTION
## What

Switches the `Co-Authored-By` trailer email from `sigit@sigit.si` to the GitHub noreply address `297239231+sigitc@users.noreply.github.com` (for the `sigitc` account), in `src/tools.rs` (the `COMMIT_CO_AUTHOR_TRAILER` const and its doc comment) and `src/main.rs` (the system prompt).

## Why

GitHub only attributes a co-authored commit to a profile when the trailer email matches an address GitHub knows for that account. Using the `sigitc` account's noreply address makes co-author attribution to the siGit Code profile reliable.

## Verification

- `cargo build` passes.