### PR TITLE
Release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.4.1
+
+Two small fixes: correct co-author attribution and a Homebrew tap fix.
+
+### What changed
+
+- The `Co-Authored-By` trailer siGit Code adds to commits now uses the GitHub
+  noreply address for the [sigitc](https://github.com/sigitc) account instead
+  of `sigit@sigit.si`, so GitHub reliably attributes co-authored commits to
+  the siGit Code profile
+- Fixed the Homebrew tap install docs to trust the tap with `brew trust`
+  instead of a `brew tap --force` flag
+
 ## 1.4.0
 
 Adds a headless one-shot mode, fine-grained permission rules, stdio transport

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5200,7 +5200,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sigit"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigit"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2024"
 description = "siGit Code — ACP-compatible AI coding agent. Sí, git."
 documentation = "https://github.com/getsigit/sigit"


### PR DESCRIPTION
## Summary
- Bump crate version to 1.4.1 in `Cargo.toml` and `Cargo.lock`
- Add `CHANGELOG.md` entry for 1.4.1, covering the two fixes already merged to `development` since 1.4.0: the noreply co-author trailer email and the Homebrew tap trust docs fix

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --tests -- -D warnings`
- [x] `cargo test --locked`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xhq1frjePKCnAJKpFGxWKA)_