### PR TITLE
Serialize cwd-mutating tests on ENV_TEST_LOCK

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -342,6 +342,9 @@ mod tests {
 
     #[test]
     fn discover_and_resolve_roundtrip() {
+        let _guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let root = unique_dir("roundtrip");
         let commands_root = root.join(".sigit").join("commands");
         fs::create_dir_all(commands_root.join("git")).unwrap();
@@ -379,6 +382,9 @@ mod tests {
 
     #[test]
     fn format_commands_list_reports_none_found() {
+        let _guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let root = unique_dir("empty");
         fs::create_dir_all(&root).unwrap();
         let prev = std::env::current_dir().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,9 +48,11 @@ mod skills;
 mod subagents;
 mod tools;
 
-/// Serializes tests that mutate process-global env vars (`SIGIT_CONFIG_DIR`
-/// etc.). `cargo test` runs tests in parallel within a binary, so without this
-/// the credentials and settings round-trip tests clobber each other's env.
+/// Serializes tests that mutate process-global state: env vars
+/// (`SIGIT_CONFIG_DIR` etc.) and the current directory. `cargo test` runs
+/// tests in parallel within a binary, so without this the credentials and
+/// settings round-trip tests clobber each other's env, and the discovery
+/// tests (skills/commands/subagents) yank the cwd out from under each other.
 #[cfg(test)]
 pub(crate) static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -414,6 +414,9 @@ mod tests {
 
     #[test]
     fn discover_and_activate_roundtrip() {
+        let _guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let root = unique_dir("roundtrip");
         let skills_root = root.join(".sigit").join("skills");
         let skill_dir = skills_root.join("hello-world");

--- a/src/subagents.rs
+++ b/src/subagents.rs
@@ -282,6 +282,9 @@ mod tests {
 
     #[test]
     fn discover_and_resolve_roundtrip() {
+        let _guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let root = unique_dir("roundtrip");
         let agents_root = root.join(".sigit").join("agents");
         fs::create_dir_all(&agents_root).unwrap();
@@ -308,6 +311,9 @@ mod tests {
 
     #[test]
     fn format_agent_types_list_reports_none_found() {
+        let _guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let root = unique_dir("empty");
         fs::create_dir_all(&root).unwrap();
         let prev = std::env::current_dir().unwrap();

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -3602,6 +3602,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // see the ENV_TEST_LOCK comment inside
     async fn test_task_runs_subagent_end_to_end() {
         // A file only the subagent's read_file call can surface.
         let dir = std::env::temp_dir().join("sigit_test_subagent_e2e");
@@ -3711,6 +3712,17 @@ mod tests {
         )
         .unwrap();
 
+        // Serialize the cwd change against the other discovery tests
+        // (skills/commands/subagents) — the cwd is process-global and cargo
+        // runs tests in parallel. The guard is held across the `.await`
+        // below on purpose: the cwd must stay pinned while `execute_tool`
+        // runs agent-type discovery. That's safe here — each `#[tokio::test]`
+        // gets its own single-threaded runtime on its own test thread, so no
+        // other task on this executor can contend for the lock — hence the
+        // `await_holding_lock` allow on this test.
+        let _env_guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let prev_cwd = std::env::current_dir().unwrap();
         std::env::set_current_dir(&dir).unwrap();
 


### PR DESCRIPTION
CI on development went red on macOS x86_64: `subagents::discover_and_resolve_roundtrip` asserted 0 == 1. The test changes the process-wide cwd before running discovery, and cargo runs tests in parallel, so `format_agent_types_list_reports_none_found` had moved the process into its own empty temp dir at exactly the wrong moment. Same latent race in the skills, commands, and tools discovery tests; it just happened to fire on that runner first.

The fix reuses `ENV_TEST_LOCK`, which already serializes the env-var mutating tests. The cwd is the same kind of process-global state (discovery also reads `SIGIT_CONFIG_DIR`), so all six cwd-mutating tests now take the same lock. The async subagent e2e test holds the guard across an await on purpose: each `#[tokio::test]` gets its own single-threaded runtime, so nothing on that executor can contend for the lock. There's a comment in the test explaining this, plus an `await_holding_lock` allow.

Verified with the full local CI gate (fmt, clippy `-D warnings`, `cargo test --locked`) and five repeat runs of the unit suite to stress the interleaving.