### PR TITLE
Fix post-v1.4.1 review findings

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -686,8 +686,20 @@ mod tui {
         }
     }
 
+    /// Identifies which list row a detail fetch belongs to, so a slow reply
+    /// can be matched against the currently-open detail and dropped if the
+    /// user has since navigated elsewhere.
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    struct RepoTarget {
+        section: RepoSection,
+        number: u64,
+    }
+
     /// The full-tab detail view opened with Enter on a list row.
     struct RepoDetail {
+        /// Which issue/PR this view is showing; matched against arriving
+        /// `RepoUpdate::Detail` replies so a stale fetch can't fill it.
+        target: RepoTarget,
         title: String,
         /// `None` while the `get_issue` / `get_pull_request` fetch runs.
         text: Option<String>,
@@ -699,7 +711,7 @@ mod tui {
     enum RepoUpdate {
         Issues(Result<Vec<RepoItem>, String>),
         PullRequests(Result<Vec<RepoItem>, String>),
-        Detail(String),
+        Detail { target: RepoTarget, text: String },
     }
 
     // ── App state ─────────────────────────────────────────────────────────────
@@ -1514,7 +1526,12 @@ mod tui {
         };
 
         let number = item.number;
+        let target = RepoTarget {
+            section: app.repo_section,
+            number,
+        };
         app.repo_detail = Some(RepoDetail {
+            target,
             title: format!("{label} #{number} — {}", item.title),
             text: None,
             scroll: 0,
@@ -1527,7 +1544,10 @@ mod tui {
         let args = serde_json::json!({ "repo": repo, "number": number }).to_string();
         tokio::spawn(async move {
             let text = crate::mcp::call_tool(&tool, &args).await;
-            let _ = tx.send(RepoUpdate::Detail(super::format_repo_detail(&text)));
+            let _ = tx.send(RepoUpdate::Detail {
+                target,
+                text: super::format_repo_detail(&text),
+            });
         });
     }
 
@@ -1599,11 +1619,22 @@ mod tui {
             Tab::Repo => {
                 // Detail view open: Up/Down scroll it; Esc (handled in the
                 // event loop) closes it back to the list.
-                if let Some(detail) = app.repo_detail.as_mut() {
+                if app.repo_detail.is_some() {
                     match key.code {
-                        KeyCode::Up => detail.scroll = detail.scroll.saturating_sub(1),
-                        KeyCode::Down => detail.scroll = detail.scroll.saturating_add(1),
-                        KeyCode::Char('r') => refresh_repo(app),
+                        KeyCode::Up => {
+                            if let Some(detail) = app.repo_detail.as_mut() {
+                                detail.scroll = detail.scroll.saturating_sub(1);
+                            }
+                        }
+                        KeyCode::Down => {
+                            if let Some(detail) = app.repo_detail.as_mut() {
+                                detail.scroll = detail.scroll.saturating_add(1);
+                            }
+                        }
+                        // "r refresh" (as the footer advertises) re-fetches the
+                        // item on screen, rather than closing the view back to
+                        // the list as refresh_repo would.
+                        KeyCode::Char('r') => open_repo_detail(app),
                         _ => {}
                     }
                     return;
@@ -3505,9 +3536,14 @@ mod tui {
                                 .repo_pr_index
                                 .min(app.repo_prs.len().saturating_sub(1));
                         }
-                        Some(RepoUpdate::Detail(text)) => {
-                            // Ignored if the user already closed the view.
-                            if let Some(detail) = app.repo_detail.as_mut() {
+                        Some(RepoUpdate::Detail { target, text }) => {
+                            // Apply only to the matching open view: a reply for
+                            // a detail the user has since closed or navigated
+                            // away from is dropped, never shown under the wrong
+                            // title.
+                            if let Some(detail) = app.repo_detail.as_mut()
+                                && detail.target == target
+                            {
                                 detail.text = Some(text);
                             }
                         }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -81,21 +81,41 @@ pub fn resolve_command(name: &str) -> Option<CustomCommand> {
 /// silently dropped.
 pub fn render(body: &str, arguments: Option<&str>) -> String {
     let arguments = arguments.unwrap_or("");
-    let mut result = body.to_string();
-    let mut substituted = false;
-
-    if result.contains("$ARGUMENTS") {
-        result = result.replace("$ARGUMENTS", arguments);
-        substituted = true;
-    }
-
     let positional: Vec<&str> = arguments.split_whitespace().collect();
-    for (i, arg) in positional.iter().enumerate() {
-        let placeholder = format!("${}", i + 1);
-        if result.contains(&placeholder) {
-            result = result.replace(&placeholder, arg);
-            substituted = true;
+
+    // Substitute in a single left-to-right pass over the template so text we
+    // insert is never re-scanned for further placeholders. A second pass (as
+    // this once did) would re-expand a literal `$1` that appeared inside the
+    // user's own `$ARGUMENTS`, corrupting prompts that mention shell
+    // positional variables.
+    let mut result = String::with_capacity(body.len());
+    let mut substituted = false;
+    let bytes = body.as_bytes();
+    let mut i = 0;
+    while i < body.len() {
+        if bytes[i] == b'$' {
+            if body[i..].starts_with("$ARGUMENTS") {
+                result.push_str(arguments);
+                substituted = true;
+                i += "$ARGUMENTS".len();
+                continue;
+            }
+            // Positional `$1`..`$9`, but only when that argument was supplied;
+            // otherwise leave the placeholder untouched (as before).
+            if let Some(&d) = bytes.get(i + 1)
+                && d.is_ascii_digit()
+                && d != b'0'
+                && let Some(arg) = positional.get((d - b'1') as usize)
+            {
+                result.push_str(arg);
+                substituted = true;
+                i += 2;
+                continue;
+            }
         }
+        let ch = body[i..].chars().next().unwrap();
+        result.push(ch);
+        i += ch.len_utf8();
     }
 
     if !substituted && !arguments.is_empty() {
@@ -298,6 +318,24 @@ mod tests {
             render(body, Some("main feature-x")),
             "Compare main against feature-x."
         );
+    }
+
+    #[test]
+    fn render_does_not_re_expand_positional_vars_inside_arguments() {
+        // A literal `$1` typed by the user must survive: the single pass
+        // substitutes $ARGUMENTS once and never re-scans the inserted text.
+        let body = "Explain: $ARGUMENTS";
+        assert_eq!(
+            render(body, Some("what does $1 mean in bash")),
+            "Explain: what does $1 mean in bash"
+        );
+    }
+
+    #[test]
+    fn render_leaves_unsupplied_positional_placeholder_literal() {
+        let body = "Compare $1 against $2.";
+        // Only one argument supplied: $2 stays untouched, like the old pass.
+        assert_eq!(render(body, Some("main")), "Compare main against $2.");
     }
 
     #[test]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -342,6 +342,9 @@ mod tests {
 
     #[test]
     fn discover_and_resolve_roundtrip() {
+        let _guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let root = unique_dir("roundtrip");
         let commands_root = root.join(".sigit").join("commands");
         fs::create_dir_all(commands_root.join("git")).unwrap();
@@ -379,6 +382,9 @@ mod tests {
 
     #[test]
     fn format_commands_list_reports_none_found() {
+        let _guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let root = unique_dir("empty");
         fs::create_dir_all(&root).unwrap();
         let prev = std::env::current_dir().unwrap();

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -94,28 +94,35 @@ pub fn unquote(value: &str) -> String {
 /// Return the content after the frontmatter block, or the whole input if
 /// there is no frontmatter.
 pub fn strip_frontmatter(contents: &str) -> &str {
+    // Mirror `extract_frontmatter`'s leniency exactly: tolerate a UTF-8 BOM,
+    // leading blank lines before the opener, and CRLF line endings (compare
+    // trimmed lines). If the two disagree, a file whose frontmatter parses
+    // still leaks that raw block into the body — see the round-trip test.
     let trimmed = contents.trim_start_matches('\u{feff}');
-    let after_opener = match trimmed.strip_prefix("---") {
-        Some(rest) => match rest.strip_prefix('\n') {
-            Some(rest) => rest,
-            None => return contents,
-        },
-        None => return contents,
-    };
-    // Find the closing `---` line.
-    let mut search = after_opener;
-    let mut offset = 0;
+    let mut rest = trimmed;
     loop {
-        let end = search.find('\n').map(|i| i + 1).unwrap_or(search.len());
-        let (line, after) = search.split_at(end);
-        if line.trim() == "---" {
-            return &after_opener[offset + end..];
+        let line_end = rest.find('\n').map(|i| i + 1).unwrap_or(rest.len());
+        let (line, after) = rest.split_at(line_end);
+        if line.trim().is_empty() {
+            rest = after;
+            continue;
         }
-        if after.is_empty() {
+        if line.trim() != "---" {
             return contents;
         }
-        offset += end;
-        search = after;
+        // `after` begins just past the opening `---` line; find the closing one.
+        let mut search = after;
+        loop {
+            let end = search.find('\n').map(|i| i + 1).unwrap_or(search.len());
+            let (l, a) = search.split_at(end);
+            if l.trim() == "---" {
+                return a;
+            }
+            if a.is_empty() {
+                return contents;
+            }
+            search = a;
+        }
     }
 }
 
@@ -165,5 +172,29 @@ mod tests {
     #[test]
     fn strip_frontmatter_passes_through_without_block() {
         assert_eq!(strip_frontmatter("just body"), "just body");
+    }
+
+    #[test]
+    fn extract_and_strip_agree_on_crlf_and_leading_blanks() {
+        // Whenever extract_frontmatter finds a block, strip_frontmatter must
+        // remove exactly that block and never leak it into the body. These
+        // inputs (CRLF endings, a leading blank line, a BOM) parse fine in
+        // extract but used to defeat strip's byte-exact opener check.
+        for md in [
+            "---\r\nname: foo\r\ndescription: bar\r\n---\r\n\r\nBody.\r\n",
+            "\n---\nname: foo\ndescription: bar\n---\n\nBody.\n",
+            "\u{feff}---\nname: foo\ndescription: bar\n---\n\nBody.\n",
+        ] {
+            assert!(
+                extract_frontmatter(md).is_some(),
+                "extract should find frontmatter in {md:?}"
+            );
+            let body = strip_frontmatter(md);
+            assert!(
+                !body.contains("name: foo"),
+                "frontmatter leaked into body for {md:?}: {body:?}"
+            );
+            assert_eq!(body.trim(), "Body.");
+        }
     }
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -33,8 +33,16 @@
 //! "top-level only" mode today.
 
 use serde::{Deserialize, Serialize};
+use std::io::Read;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// How long a single hook command may run before it is killed, unless
+/// `[hooks] timeout_secs` overrides it. Without a bound, a hook that never
+/// exits (waits on input, a stalled network mount, a deadlock) blocks the
+/// tool call or session start that fired it forever.
+const DEFAULT_HOOK_TIMEOUT_SECS: u64 = 30;
 
 /// Hook configuration: lists of shell commands to run at key moments.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -48,6 +56,11 @@ pub struct HookSettings {
     /// Commands to run after a tool is executed.
     #[serde(default)]
     pub post_tool_use: Vec<String>,
+    /// Per-hook wall-clock limit in seconds. `None` uses
+    /// [`DEFAULT_HOOK_TIMEOUT_SECS`]. Raise it for slow hooks (a build, a
+    /// linter); a hook that exceeds it is killed and logged.
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
 }
 
 impl HookSettings {
@@ -56,6 +69,11 @@ impl HookSettings {
         !self.session_start.is_empty()
             || !self.pre_tool_use.is_empty()
             || !self.post_tool_use.is_empty()
+    }
+
+    /// The wall-clock limit applied to each hook command.
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(self.timeout_secs.unwrap_or(DEFAULT_HOOK_TIMEOUT_SECS))
     }
 }
 
@@ -167,37 +185,86 @@ fn windows_quote(value: &str) -> String {
 /// (`SIGIT_HOOK_CWD`, `SIGIT_HOOK_SESSION_ID`, `SIGIT_HOOK_TOOL_NAME`,
 /// `SIGIT_HOOK_TOOL_ARGS_LEN`, `SIGIT_HOOK_TOOL_RESULT_LEN`) so hook scripts
 /// can read them without any quoting concerns at all.
-fn run_hook(cmd: &str, context: &HookContext, cwd: &Path) {
+fn run_hook(cmd: &str, context: &HookContext, cwd: &Path, timeout: Duration) {
     #[cfg(unix)]
     let (shell, flag, substituted) = ("sh", "-c", context.substitute(cmd, posix_quote));
     #[cfg(windows)]
     let (shell, flag, substituted) = ("cmd", "/C", context.substitute(cmd, windows_quote));
 
     log::debug!("Running hook: {substituted}");
-    match Command::new(shell)
+    let mut child = match Command::new(shell)
         .arg(flag)
         .arg(&substituted)
         .current_dir(cwd)
         .envs(context.env_vars())
-        .output()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
     {
-        Ok(output) => {
-            if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                log::warn!(
-                    "Hook failed with status {:?}: {}",
-                    output.status.code(),
-                    stderr.trim()
-                );
-            } else {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                if !stdout.is_empty() {
-                    log::debug!("Hook output: {}", stdout.trim());
-                }
-            }
-        }
+        Ok(child) => child,
         Err(err) => {
             log::warn!("Failed to run hook: {err}");
+            return;
+        }
+    };
+
+    // Drain stdout/stderr on their own threads so a hook that writes more than
+    // the pipe buffer holds (a build, say) keeps making progress instead of
+    // blocking on a full pipe and looking like a hang. The main thread polls
+    // for exit and enforces the deadline.
+    fn drain<R: Read + Send + 'static>(pipe: Option<R>) -> std::thread::JoinHandle<Vec<u8>> {
+        std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            if let Some(mut p) = pipe {
+                let _ = p.read_to_end(&mut buf);
+            }
+            buf
+        })
+    }
+    let stdout_handle = drain(child.stdout.take());
+    let stderr_handle = drain(child.stderr.take());
+
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(err) => {
+                log::warn!("Failed to wait on hook: {err}");
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
+        }
+    };
+
+    // The child has exited (or been killed), so both pipes are closed and the
+    // drain threads finish promptly.
+    let stdout = stdout_handle.join().unwrap_or_default();
+    let stderr = stderr_handle.join().unwrap_or_default();
+
+    match status {
+        None => log::warn!(
+            "Hook timed out after {}s and was killed: {substituted}",
+            timeout.as_secs()
+        ),
+        Some(status) if !status.success() => log::warn!(
+            "Hook failed with status {:?}: {}",
+            status.code(),
+            String::from_utf8_lossy(&stderr).trim()
+        ),
+        Some(_) => {
+            let out = String::from_utf8_lossy(&stdout);
+            if !out.trim().is_empty() {
+                log::debug!("Hook output: {}", out.trim());
+            }
         }
     }
 }
@@ -214,7 +281,7 @@ pub fn run_session_start_hooks(hooks: &HookSettings, cwd: &Path, session_id: &st
         ..HookContext::new()
     };
     for cmd in &hooks.session_start {
-        run_hook(cmd, &context, cwd);
+        run_hook(cmd, &context, cwd, hooks.timeout());
     }
 }
 
@@ -231,7 +298,7 @@ pub fn run_pre_tool_use_hooks(hooks: &HookSettings, tool_name: &str, tool_args: 
         ..HookContext::new()
     };
     for cmd in &hooks.pre_tool_use {
-        run_hook(cmd, &context, cwd);
+        run_hook(cmd, &context, cwd, hooks.timeout());
     }
 }
 
@@ -253,13 +320,47 @@ pub fn run_post_tool_use_hooks(
         ..HookContext::new()
     };
     for cmd in &hooks.post_tool_use {
-        run_hook(cmd, &context, cwd);
+        run_hook(cmd, &context, cwd, hooks.timeout());
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn hook_that_hangs_is_killed_at_the_timeout() {
+        // A hook that would sleep far past the deadline must be killed near it,
+        // not block the caller for the full sleep.
+        let context = HookContext::new();
+        let start = Instant::now();
+        run_hook(
+            "sleep 30",
+            &context,
+            Path::new("."),
+            Duration::from_millis(300),
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "hook should have been killed shortly after its 300ms timeout, took {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[test]
+    fn timeout_defaults_when_unset_and_honors_override() {
+        let default = HookSettings::default();
+        assert_eq!(
+            default.timeout(),
+            Duration::from_secs(DEFAULT_HOOK_TIMEOUT_SECS)
+        );
+        let custom = HookSettings {
+            timeout_secs: Some(5),
+            ..HookSettings::default()
+        };
+        assert_eq!(custom.timeout(), Duration::from_secs(5));
+    }
 
     #[test]
     fn test_hook_context_substitution() {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -192,15 +192,22 @@ fn run_hook(cmd: &str, context: &HookContext, cwd: &Path, timeout: Duration) {
     let (shell, flag, substituted) = ("cmd", "/C", context.substitute(cmd, windows_quote));
 
     log::debug!("Running hook: {substituted}");
-    let mut child = match Command::new(shell)
+    let mut command = Command::new(shell);
+    command
         .arg(flag)
         .arg(&substituted)
         .current_dir(cwd)
         .envs(context.env_vars())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-    {
+        .stderr(Stdio::piped());
+    // Put the hook in its own process group so a timeout kill can take out the
+    // whole tree. Killing just the shell is not enough: `sh -c` may fork
+    // rather than exec (dash does), and the surviving grandchild would both
+    // keep running and hold the pipe write ends open, blocking the drains
+    // below until it exits on its own.
+    #[cfg(unix)]
+    std::os::unix::process::CommandExt::process_group(&mut command, 0);
+    let mut child = match command.spawn() {
         Ok(child) => child,
         Err(err) => {
             log::warn!("Failed to run hook: {err}");
@@ -208,21 +215,40 @@ fn run_hook(cmd: &str, context: &HookContext, cwd: &Path, timeout: Duration) {
         }
     };
 
+    #[cfg(unix)]
+    fn kill_hook(child: &mut std::process::Child) {
+        // SIGKILL the process group (negative pid); the child is its leader.
+        // Fall back to killing the child alone if that fails.
+        if unsafe { libc::kill(-(child.id() as i32), libc::SIGKILL) } != 0 {
+            let _ = child.kill();
+        }
+        let _ = child.wait();
+    }
+    #[cfg(windows)]
+    fn kill_hook(child: &mut std::process::Child) {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
     // Drain stdout/stderr on their own threads so a hook that writes more than
     // the pipe buffer holds (a build, say) keeps making progress instead of
-    // blocking on a full pipe and looking like a hang. The main thread polls
-    // for exit and enforces the deadline.
-    fn drain<R: Read + Send + 'static>(pipe: Option<R>) -> std::thread::JoinHandle<Vec<u8>> {
+    // blocking on a full pipe and looking like a hang. The threads report back
+    // over a channel rather than being joined: a receive can be bounded, while
+    // a join could block forever on a pipe a detached grandchild still holds.
+    let (out_tx, out_rx) = std::sync::mpsc::channel::<(u8, Vec<u8>)>();
+    let drain = |tag: u8, pipe: Option<Box<dyn Read + Send>>| {
+        let tx = out_tx.clone();
         std::thread::spawn(move || {
             let mut buf = Vec::new();
             if let Some(mut p) = pipe {
                 let _ = p.read_to_end(&mut buf);
             }
-            buf
-        })
-    }
-    let stdout_handle = drain(child.stdout.take());
-    let stderr_handle = drain(child.stderr.take());
+            let _ = tx.send((tag, buf));
+        });
+    };
+    drain(0, child.stdout.take().map(|p| Box::new(p) as _));
+    drain(1, child.stderr.take().map(|p| Box::new(p) as _));
+    drop(out_tx);
 
     let deadline = Instant::now() + timeout;
     let status = loop {
@@ -230,25 +256,36 @@ fn run_hook(cmd: &str, context: &HookContext, cwd: &Path, timeout: Duration) {
             Ok(Some(status)) => break Some(status),
             Ok(None) => {
                 if Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
+                    kill_hook(&mut child);
                     break None;
                 }
                 std::thread::sleep(Duration::from_millis(50));
             }
             Err(err) => {
                 log::warn!("Failed to wait on hook: {err}");
-                let _ = child.kill();
-                let _ = child.wait();
+                kill_hook(&mut child);
                 break None;
             }
         }
     };
 
-    // The child has exited (or been killed), so both pipes are closed and the
-    // drain threads finish promptly.
-    let stdout = stdout_handle.join().unwrap_or_default();
-    let stderr = stderr_handle.join().unwrap_or_default();
+    // Collect what the drains read, bounded: if something in the hook's tree
+    // outlived the kill (or daemonized past the process group) and still holds
+    // a pipe open, give up on its output after a short grace instead of
+    // hanging the caller on it.
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let grace = Duration::from_secs(1);
+    for _ in 0..2 {
+        match out_rx.recv_timeout(grace) {
+            Ok((0, buf)) => stdout = buf,
+            Ok((_, buf)) => stderr = buf,
+            Err(_) => {
+                log::debug!("Hook output pipe still open after exit; skipping its output");
+                break;
+            }
+        }
+    }
 
     match status {
         None => log::warn!(
@@ -331,12 +368,16 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn hook_that_hangs_is_killed_at_the_timeout() {
-        // A hook that would sleep far past the deadline must be killed near it,
-        // not block the caller for the full sleep.
+        // A hook that would sleep far past the deadline must be killed near
+        // it, not block the caller for the full sleep. The two-command form
+        // forces the shell to fork `sleep` rather than exec it (what dash does
+        // even for a single command), so this also proves the kill takes out
+        // the whole process group: a surviving grandchild would hold the
+        // output pipes open and stall the caller until its own exit.
         let context = HookContext::new();
         let start = Instant::now();
         run_hook(
-            "sleep 30",
+            "sleep 30; echo done",
             &context,
             Path::new("."),
             Duration::from_millis(300),

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,9 +48,11 @@ mod skills;
 mod subagents;
 mod tools;
 
-/// Serializes tests that mutate process-global env vars (`SIGIT_CONFIG_DIR`
-/// etc.). `cargo test` runs tests in parallel within a binary, so without this
-/// the credentials and settings round-trip tests clobber each other's env.
+/// Serializes tests that mutate process-global state: env vars
+/// (`SIGIT_CONFIG_DIR` etc.) and the current directory. `cargo test` runs
+/// tests in parallel within a binary, so without this the credentials and
+/// settings round-trip tests clobber each other's env, and the discovery
+/// tests (skills/commands/subagents) yank the cwd out from under each other.
 #[cfg(test)]
 pub(crate) static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -242,11 +242,42 @@ fn matchable_argument(tool_name: &str, arguments: &str) -> Option<String> {
 /// string, consulted by rule patterns and granular session grants. See the
 /// module docs for the layering.
 pub fn decision_for(session: &str, tool_name: &str, arguments: &str) -> Decision {
-    if classify(tool_name) == ToolRisk::ReadOnly {
+    let read_only = classify(tool_name) == ToolRisk::ReadOnly;
+    let argument = matchable_argument(tool_name, arguments);
+    let rules = settings::permission_rules();
+
+    // An explicit deny applies to every tool, read-only ones included. This is
+    // what lets a user still switch off a first-party query tool that
+    // `classify` now treats as read-only (`web_search`, `list_issues`, …);
+    // without it, the reclassification would silently stop honoring a deny that
+    // was enforced when those names counted as mutating.
+    if let Some(rule) = rules
+        .deny
+        .iter()
+        .find(|rule| rule_matches(rule, tool_name, argument.as_deref()))
+    {
+        return Decision::Deny(format!(
+            "`{tool_name}` is denied by the permission rule `{rule}` in settings.toml. \
+             Do not retry it; work without this tool or ask the user to change \
+             the policy."
+        ));
+    }
+
+    if read_only {
+        // Read-only tools never prompt and are never plan-mode blocked, but an
+        // explicit per-tool `deny` still turns one off. Crucially we consult
+        // the *explicit* override, not `permission_mode_for`, so the default
+        // `ask`/`deny` mode never starts prompting on every read_file.
+        if settings::permission_mode_explicit(tool_name) == Some(PermissionMode::Deny) {
+            return Decision::Deny(format!(
+                "`{tool_name}` is denied by the permission policy in settings.toml. \
+                 Do not retry it; work without this tool or ask the user to change \
+                 the policy."
+            ));
+        }
         return Decision::Allow;
     }
 
-    let argument = matchable_argument(tool_name, arguments);
     let (plan_mode, granted) = with_session(session, |s| {
         (
             s.plan_mode,
@@ -263,18 +294,6 @@ pub fn decision_for(session: &str, tool_name: &str, arguments: &str) -> Decision
         return Decision::Allow;
     }
 
-    let rules = settings::permission_rules();
-    if let Some(rule) = rules
-        .deny
-        .iter()
-        .find(|rule| rule_matches(rule, tool_name, argument.as_deref()))
-    {
-        return Decision::Deny(format!(
-            "`{tool_name}` is denied by the permission rule `{rule}` in settings.toml. \
-             Do not retry it; work without this tool or ask the user to change \
-             the policy."
-        ));
-    }
     if rules
         .allow
         .iter()
@@ -484,6 +503,39 @@ mod tests {
                 "{tool}"
             );
         }
+    }
+
+    #[test]
+    fn read_only_tool_still_honors_an_explicit_deny() {
+        let _guard = env_guard();
+        // A deny rule listing a read-only first-party query tool is enforced,
+        // even though the tool never prompts otherwise.
+        store_rules(&[], &["mcp__sigit__web_search"]);
+        assert!(matches!(
+            decision_for("t", "mcp__sigit__web_search", "{}"),
+            Decision::Deny(_)
+        ));
+        // A tool with no deny rule is unaffected.
+        assert_eq!(
+            decision_for("t", "mcp__sigit__list_issues", "{}"),
+            Decision::Allow
+        );
+
+        // An explicit per-tool `deny` mode also turns a read-only tool off,
+        // while the default mode never makes read-only tools prompt.
+        let mut settings = settings::load();
+        settings.permissions.rules.deny.clear();
+        settings.permissions.default = PermissionMode::Ask;
+        settings
+            .permissions
+            .tools
+            .insert("mcp__sigit__web_search".to_string(), PermissionMode::Deny);
+        settings::store(&settings).unwrap();
+        assert!(matches!(
+            decision_for("t", "mcp__sigit__web_search", "{}"),
+            Decision::Deny(_)
+        ));
+        assert_eq!(decision_for("t", "read_file", "{}"), Decision::Allow);
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -229,6 +229,14 @@ pub fn permission_rules() -> PermissionRules {
     load().permissions.rules
 }
 
+/// The tool's explicit `[permissions.tools]` override, or `None` when it has
+/// no entry. Unlike [`permission_mode_for`] this never falls back to the
+/// default or the env override, so callers can tell "the user set a mode for
+/// this exact tool" apart from "the tool inherits the default".
+pub fn permission_mode_explicit(tool_name: &str) -> Option<PermissionMode> {
+    load().permissions.tools.get(tool_name).copied()
+}
+
 /// The effective permission mode for one tool: its `[permissions.tools]`
 /// override when present, else the default (see [`permission_default`]).
 pub fn permission_mode_for(tool_name: &str) -> PermissionMode {

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -414,6 +414,9 @@ mod tests {
 
     #[test]
     fn discover_and_activate_roundtrip() {
+        let _guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let root = unique_dir("roundtrip");
         let skills_root = root.join(".sigit").join("skills");
         let skill_dir = skills_root.join("hello-world");

--- a/src/subagents.rs
+++ b/src/subagents.rs
@@ -282,6 +282,9 @@ mod tests {
 
     #[test]
     fn discover_and_resolve_roundtrip() {
+        let _guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let root = unique_dir("roundtrip");
         let agents_root = root.join(".sigit").join("agents");
         fs::create_dir_all(&agents_root).unwrap();
@@ -308,6 +311,9 @@ mod tests {
 
     #[test]
     fn format_agent_types_list_reports_none_found() {
+        let _guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let root = unique_dir("empty");
         fs::create_dir_all(&root).unwrap();
         let prev = std::env::current_dir().unwrap();

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -688,13 +688,15 @@ fn subagent_tool_specs(allowed: &[String]) -> Vec<ToolSpec> {
 /// base read-only set; anything else it lists is dropped with a warning
 /// rather than silently granted, since that's the whole security property
 /// this function exists to enforce (see the module doc above).
-fn effective_subagent_tools(agent_type: Option<&subagents::AgentType>) -> Vec<String> {
+fn effective_subagent_tools(
+    agent_type: Option<&subagents::AgentType>,
+) -> Result<Vec<String>, String> {
     let Some(agent_type) = agent_type else {
-        return SUBAGENT_TOOL_NAMES.iter().map(|s| s.to_string()).collect();
+        return Ok(SUBAGENT_TOOL_NAMES.iter().map(|s| s.to_string()).collect());
     };
     let Some(requested) = &agent_type.tools else {
         // No `tools:` field: inherit the full default read-only set.
-        return SUBAGENT_TOOL_NAMES.iter().map(|s| s.to_string()).collect();
+        return Ok(SUBAGENT_TOOL_NAMES.iter().map(|s| s.to_string()).collect());
     };
 
     let mut effective = Vec::new();
@@ -711,7 +713,23 @@ fn effective_subagent_tools(agent_type: Option<&subagents::AgentType>) -> Vec<St
             );
         }
     }
-    effective
+
+    // A `tools:` field that intersects the ceiling to nothing is a
+    // misconfiguration, not a request for a toolless subagent: running it
+    // anyway would answer from the model's priors with no file access and no
+    // signal beyond a log line. Surface it as an error instead.
+    if effective.is_empty() {
+        return Err(format!(
+            "Error: subagent type \"{}\" at {} sets `tools: {}`, none of which \
+             is in the subagent read-only set ({}). Fix the type's `tools:` \
+             field, or omit it to inherit the default read-only tools.",
+            agent_type.name,
+            agent_type.path.display(),
+            requested.join(", "),
+            SUBAGENT_TOOL_NAMES.join(", "),
+        ));
+    }
+    Ok(effective)
 }
 
 /// Spec for the `task` tool. Lives in the `*_as_specs`/`build_tool_specs`
@@ -829,7 +847,10 @@ async fn exec_task_with(arguments: &str, factory: Option<&SubagentFactory>) -> S
         .as_ref()
         .map(|t| t.system_prompt.as_str())
         .unwrap_or(SUBAGENT_SYSTEM_PROMPT);
-    let allowed_tools = effective_subagent_tools(agent_type.as_ref());
+    let allowed_tools = match effective_subagent_tools(agent_type.as_ref()) {
+        Ok(tools) => tools,
+        Err(err) => return err,
+    };
 
     let Some(backend) = factory.and_then(|build| build(system_prompt)) else {
         return SUBAGENT_UNAVAILABLE.to_string();
@@ -3330,7 +3351,7 @@ mod tests {
 
     #[test]
     fn test_subagent_toolset_is_read_only() {
-        let specs = subagent_tool_specs(&effective_subagent_tools(None));
+        let specs = subagent_tool_specs(&effective_subagent_tools(None).unwrap());
         let mut names: Vec<&str> = specs.iter().map(|spec| spec.name.as_str()).collect();
         names.sort_unstable();
         assert_eq!(
@@ -3762,7 +3783,7 @@ mod tests {
 
     #[test]
     fn effective_subagent_tools_defaults_to_full_read_only_set_without_a_type() {
-        let mut tools = effective_subagent_tools(None);
+        let mut tools = effective_subagent_tools(None).unwrap();
         tools.sort();
         let mut expected: Vec<String> = SUBAGENT_TOOL_NAMES.iter().map(|s| s.to_string()).collect();
         expected.sort();
@@ -3778,7 +3799,7 @@ mod tests {
             system_prompt: "Be helpful.".to_string(),
             path: PathBuf::from("/x/generalist.md"),
         };
-        let mut tools = effective_subagent_tools(Some(&agent_type));
+        let mut tools = effective_subagent_tools(Some(&agent_type)).unwrap();
         tools.sort();
         let mut expected: Vec<String> = SUBAGENT_TOOL_NAMES.iter().map(|s| s.to_string()).collect();
         expected.sort();
@@ -3794,7 +3815,7 @@ mod tests {
             system_prompt: "Read notes.".to_string(),
             path: PathBuf::from("/x/notes-reader.md"),
         };
-        let tools = effective_subagent_tools(Some(&agent_type));
+        let tools = effective_subagent_tools(Some(&agent_type)).unwrap();
         assert_eq!(tools, vec!["read_file".to_string(), "glob".to_string()]);
     }
 
@@ -3815,10 +3836,29 @@ mod tests {
             system_prompt: "...".to_string(),
             path: PathBuf::from("/x/sneaky.md"),
         };
-        let tools = effective_subagent_tools(Some(&agent_type));
+        let tools = effective_subagent_tools(Some(&agent_type)).unwrap();
         assert_eq!(tools, vec!["read_file".to_string()]);
         assert!(!tools.contains(&"edit_file".to_string()));
         assert!(!tools.contains(&"run_command".to_string()));
         assert!(!tools.contains(&"task".to_string()));
+    }
+
+    #[test]
+    fn effective_subagent_tools_errors_when_allow_list_intersects_to_nothing() {
+        // A type whose `tools:` names only out-of-ceiling tools (e.g. Claude
+        // Code names carried over) must error, not silently run toolless.
+        let agent_type = subagents::AgentType {
+            name: "misconfigured".to_string(),
+            description: "names only invalid tools".to_string(),
+            tools: Some(vec!["grep".to_string(), "bash".to_string()]),
+            system_prompt: "...".to_string(),
+            path: PathBuf::from("/x/misconfigured.md"),
+        };
+        let err = effective_subagent_tools(Some(&agent_type)).unwrap_err();
+        assert!(
+            err.contains("misconfigured"),
+            "message names the type: {err}"
+        );
+        assert!(err.contains("read-only set"), "message explains why: {err}");
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -3602,6 +3602,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // see the ENV_TEST_LOCK comment inside
     async fn test_task_runs_subagent_end_to_end() {
         // A file only the subagent's read_file call can surface.
         let dir = std::env::temp_dir().join("sigit_test_subagent_e2e");
@@ -3711,6 +3712,17 @@ mod tests {
         )
         .unwrap();
 
+        // Serialize the cwd change against the other discovery tests
+        // (skills/commands/subagents) — the cwd is process-global and cargo
+        // runs tests in parallel. The guard is held across the `.await`
+        // below on purpose: the cwd must stay pinned while `execute_tool`
+        // runs agent-type discovery. That's safe here — each `#[tokio::test]`
+        // gets its own single-threaded runtime on its own test thread, so no
+        // other task on this executor can contend for the lock — hence the
+        // `await_holding_lock` allow on this test.
+        let _env_guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let prev_cwd = std::env::current_dir().unwrap();
         std::env::set_current_dir(&dir).unwrap();
 


### PR DESCRIPTION
Fixes the seven correctness findings from the review of the five feature merges that landed after v1.4.1 (hooks, user-defined slash commands, TUI repo tabs, configurable subagents, web search). One commit per fix, each with a regression test.

**Stacked on #38.** This branch builds on `fix/discovery-test-cwd-race` so CI runs green; that branch carries only the test-race fix. Merge #38 first, then this rebases cleanly onto `development`.

## What's fixed

- **Hooks could hang the agent forever** (`hooks.rs`). `run_hook` ran with no timeout from the async tool path and the ACP session-start handlers, so a hook that never exits blocked every tool call or session creation with no way to cancel. Hooks now run under a wall-clock limit (30s default, `[hooks] timeout_secs` to override) and are killed past it. stdout/stderr drain on their own threads so a high-output hook like a build still completes.
- **Explicit denies stopped working for first-party read-only tools** (`permissions.rs`, `settings.rs`). `decision_for` returned `Allow` for any read-only tool before consulting deny rules, so once `mcp__sigit__{list_*,get_*,search_code,web_search}` became read-only, a deny that was enforced in v1.4.1 was silently ignored. Deny rules and an explicit per-tool `deny` are now honored for read-only tools too, while undenied ones still run without a prompt.
- **Frontmatter leaked into prompts on CRLF files** (`frontmatter.rs`). `extract_frontmatter` tolerated CRLF, a BOM, and leading blank lines; `strip_frontmatter` demanded an exact `---\n` at byte 0. A Windows-saved command or agent file was discovered fine but had its raw `---` block spliced into the rendered prompt. Both functions now scan lines the same way.
- **Command templates re-expanded positional vars** (`commands.rs`). `$ARGUMENTS` was substituted, then the result re-scanned for `$1..$9`, so a literal `$1` inside the user's arguments got clobbered. Substitution is now a single left-to-right pass.
- **A misconfigured subagent ran with no tools** (`tools.rs`). A `tools:` list naming only out-of-ceiling tools resolved to an empty allow-list and the subagent answered from priors with no file access. That case is now an error surfaced to the caller.
- **Repo tab detail view: stale fetches and a broken refresh** (`chat.rs`). Detail replies carried no identity, so a slow fetch could fill the wrong open view; they now carry a `RepoTarget` and mismatches are dropped. And `r` (advertised as "refresh") called `refresh_repo`, which closed the detail; it now re-fetches the item on screen.

## Verification

Full local gate green: `cargo fmt --check`, `cargo clippy --tests -- -D warnings`, `cargo test --locked` (227 unit tests, +7 new). The hook-timeout test was run repeatedly to confirm the kill path is stable.
