### PR TITLE
Bake in the smbCloud CLI's stdio MCP server

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -172,9 +172,12 @@ feeds results back. Neither the loop nor ACP/TUI surfaces depend on a concrete b
   both read it; `/reload` does *not* re-run it, so config changes need a restart. stdio children
   live for the process; a dead child fails calls with an in-band error string (no auto-restart).
   Tools are namespaced `mcp__<server>__<tool>`, appended in the `*_as_specs`/`build_tool_specs`
-  layer and routed in `tools::execute_tool` via `mcp::is_mcp_tool`. The official server
-  (`<cloud>/mcp`, default `https://sigit.si/api/v1/mcp`) is baked in (always HTTP) and authed
-  with the cloud session token; extra servers live in `mcp.toml` (global
+  layer and routed in `tools::execute_tool` via `mcp::is_mcp_tool`. Two servers are baked in:
+  the official server (`<cloud>/mcp`, default `https://sigit.si/api/v1/mcp`, always HTTP, authed
+  with the cloud session token) and the smbCloud CLI server (`smb --mcp`, stdio, added only when
+  the `smb` binary is on `PATH`; opt out with `smbcloud = false` in `mcp.toml` or
+  `SIGIT_MCP_SMBCLOUD=off`). A user-defined entry named `sigit` or `smbcloud` overrides the
+  corresponding baked-in one. Extra servers live in `mcp.toml` (global
   `$SIGIT_CONFIG_DIR/mcp.toml` and project-local `.sigit/mcp.toml`). The stdio path is covered by
   `tests/mcp_stdio.rs`, driven by the test-only `src/bin/mcp_stdio_stub.rs` helper binary
   (excluded from the published crate via `exclude` in `Cargo.toml`).
@@ -233,7 +236,8 @@ verbosity with `RUST_LOG`.
 
 `OPENAI_BASE_URL` / `OPENAI_API_KEY` (provider override), `SIGIT_API_URL` (account API base,
 default `https://sigit.si`), `SIGIT_CLOUD_URL`, `SIGIT_CONFIG_DIR` (default `~/.config/sigit`),
-`SIGIT_MODEL`, `SIGIT_MCP` (`off` disables MCP), `SIGIT_MCP_OFFICIAL` (`off` drops the baked-in
+`SIGIT_MODEL`, `SIGIT_MCP` (`off` disables MCP), `SIGIT_MCP_SMBCLOUD` (`off` drops the baked-in
+smbCloud CLI server), `SIGIT_MCP_OFFICIAL` (`off` drops the baked-in
 server), `SIGIT_PERMISSIONS` (`allow`/`ask`/`deny` — overrides the default permission mode for
 mutating tools; the escape hatch for clients without permission-request support),
 `HF_HOME` / `HF_HUB_CACHE`, `RUST_LOG`.

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -21,13 +21,21 @@
 //! `url` and `command` are mutually exclusive; an entry with both, or neither,
 //! is a config error that is logged and skipped.
 //!
-//! ## The official server
+//! ## Baked-in servers
 //!
 //! siGit Code bakes in its official MCP server at `<cloud>/mcp` (default
 //! `https://sigit.si/api/v1/mcp`, following `SIGIT_CLOUD_URL`). When the user is
 //! signed in (`sigit login`) the cloud session token is sent as a bearer
-//! credential. Additional servers are configured in `mcp.toml` (see
-//! [`load_configs`]).
+//! credential.
+//!
+//! The smbCloud CLI's MCP server (`smb --mcp`, stdio) is also baked in, but
+//! only when the `smb` binary is actually on `PATH` — no binary, no entry, no
+//! error. Opt out with `smbcloud = false` in `mcp.toml` or
+//! `SIGIT_MCP_SMBCLOUD=off`.
+//!
+//! Both baked-in entries yield to a user-defined `mcp.toml` server of the same
+//! name, so either can be repointed or reconfigured without a special case.
+//! Additional servers are configured in `mcp.toml` (see [`load_configs`]).
 //!
 //! ## Lifecycle
 //!
@@ -93,6 +101,14 @@ pub fn official_tool_suffix(name: &str) -> Option<&str> {
         .strip_prefix(OFFICIAL_SERVER_NAME)?
         .strip_prefix("__")
 }
+
+/// Name of the baked-in smbCloud CLI server; its tools are namespaced
+/// `mcp__smbcloud__<tool>`. Like the official server, a user-defined `mcp.toml`
+/// entry with this name overrides the baked-in command line.
+const SMBCLOUD_SERVER_NAME: &str = "smbcloud";
+
+/// The smbCloud CLI binary the baked-in stdio entry spawns (`smb --mcp`).
+const SMBCLOUD_COMMAND: &str = "smb";
 
 /// JSON-RPC / MCP protocol version we advertise in the handshake.
 const PROTOCOL_VERSION: &str = "2025-06-18";
@@ -303,6 +319,10 @@ struct McpFile {
     /// opt out.
     #[serde(default)]
     official: Option<bool>,
+    /// Include the baked-in smbCloud CLI server (`smb --mcp`). Defaults to
+    /// `true`; set `false` to opt out. Moot when `smb` isn't installed.
+    #[serde(default)]
+    smbcloud: Option<bool>,
     #[serde(default)]
     server: Vec<ServerEntry>,
 }
@@ -386,6 +406,7 @@ fn load_configs() -> Vec<ServerDef> {
     }
 
     let mut include_official = true;
+    let mut include_smbcloud = true;
     // De-duplicated by sanitized name; a later config file overrides an earlier
     // one for the same name (project-local wins over global).
     let mut defs: Vec<ServerDef> = Vec::new();
@@ -403,6 +424,9 @@ fn load_configs() -> Vec<ServerDef> {
         };
         if let Some(official) = parsed.official {
             include_official = official;
+        }
+        if let Some(smbcloud) = parsed.smbcloud {
+            include_smbcloud = smbcloud;
         }
         for entry in parsed.server {
             if entry.enabled == Some(false) {
@@ -453,7 +477,46 @@ fn load_configs() -> Vec<ServerDef> {
         });
     }
 
+    // The smbCloud server can also be disabled with SIGIT_MCP_SMBCLOUD=off.
+    if let Ok(value) = std::env::var("SIGIT_MCP_SMBCLOUD")
+        && matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "off" | "0" | "false" | "no"
+        )
+    {
+        include_smbcloud = false;
+    }
+
+    // Add the baked-in smbCloud CLI server, with the same never-clobber rule as
+    // the official one. Only when `smb` is actually installed: a hardwired
+    // entry for a binary most users don't have would surface a spawn failure
+    // in `/mcp` instead of just staying out of the way.
+    if include_smbcloud && !defs.iter().any(|d| d.name == SMBCLOUD_SERVER_NAME) {
+        if on_path(SMBCLOUD_COMMAND) {
+            defs.push(ServerDef {
+                name: SMBCLOUD_SERVER_NAME.to_string(),
+                transport: TransportDef::Stdio {
+                    command: SMBCLOUD_COMMAND.to_string(),
+                    args: vec!["--mcp".to_string()],
+                    env: Vec::new(),
+                },
+            });
+        } else {
+            log::debug!("mcp: `{SMBCLOUD_COMMAND}` not on PATH; skipping the smbcloud server");
+        }
+    }
+
     defs
+}
+
+/// Whether `binary` resolves to an executable file on `PATH` (with the
+/// platform's executable suffix, `.exe` on Windows).
+fn on_path(binary: &str) -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    let file = format!("{binary}{}", std::env::consts::EXE_SUFFIX);
+    std::env::split_paths(&path).any(|dir| !dir.as_os_str().is_empty() && dir.join(&file).is_file())
 }
 
 /// Insert `def`, replacing any existing entry with the same name.
@@ -1335,6 +1398,7 @@ mod tests {
         "#;
         let parsed: McpFile = toml::from_str(toml).unwrap();
         assert_eq!(parsed.official, Some(false));
+        assert_eq!(parsed.smbcloud, None);
         assert_eq!(parsed.server.len(), 2);
         assert_eq!(parsed.server[0].name, "github");
         assert_eq!(parsed.server[1].enabled, Some(false));
@@ -1345,6 +1409,22 @@ mod tests {
                 .map(String::as_str),
             Some("Bearer xyz")
         );
+    }
+
+    #[test]
+    fn parses_smbcloud_opt_out_flag() {
+        let parsed: McpFile = toml::from_str("smbcloud = false").unwrap();
+        assert_eq!(parsed.smbcloud, Some(false));
+        // Absent means "include" (the default stays true in load_configs).
+        let parsed: McpFile = toml::from_str("").unwrap();
+        assert_eq!(parsed.smbcloud, None);
+    }
+
+    #[test]
+    fn on_path_finds_real_binaries_only() {
+        assert!(!on_path("definitely-not-a-real-binary-xyzzy"));
+        #[cfg(unix)]
+        assert!(on_path("sh"));
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -110,6 +110,14 @@ const SMBCLOUD_SERVER_NAME: &str = "smbcloud";
 /// The smbCloud CLI binary the baked-in stdio entry spawns (`smb --mcp`).
 const SMBCLOUD_COMMAND: &str = "smb";
 
+/// The bare tool name when `name` belongs to the smbCloud server
+/// (`mcp__smbcloud__project_list` → `Some("project_list")`), else `None`.
+pub fn smbcloud_tool_suffix(name: &str) -> Option<&str> {
+    name.strip_prefix(MCP_PREFIX)?
+        .strip_prefix(SMBCLOUD_SERVER_NAME)?
+        .strip_prefix("__")
+}
+
 /// JSON-RPC / MCP protocol version we advertise in the handshake.
 const PROTOCOL_VERSION: &str = "2025-06-18";
 
@@ -1369,6 +1377,19 @@ mod tests {
         assert_eq!(official_tool_suffix("mcp__sigitx__list_issues"), None);
         assert_eq!(official_tool_suffix("list_issues"), None);
         assert_eq!(official_tool_suffix("mcp__sigit__"), Some(""));
+    }
+
+    #[test]
+    fn smbcloud_tool_suffix_strips_only_the_smbcloud_namespace() {
+        assert_eq!(
+            smbcloud_tool_suffix("mcp__smbcloud__project_list"),
+            Some("project_list")
+        );
+        assert_eq!(smbcloud_tool_suffix("mcp__sigit__project_list"), None);
+        // `smbcloud` must be the whole server name, not a prefix of it.
+        assert_eq!(smbcloud_tool_suffix("mcp__smbcloudx__project_list"), None);
+        assert_eq!(smbcloud_tool_suffix("project_list"), None);
+        assert_eq!(smbcloud_tool_suffix("mcp__smbcloud__"), Some(""));
     }
 
     #[test]

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -40,8 +40,9 @@
 //!
 //! Tools discovered from MCP servers (`mcp__*`) and any unknown tool name are
 //! treated as mutating: external tools can have arbitrary side effects, so the
-//! safe assumption is to gate them. The one exception is the official
-//! sigit.si server's query tools (see [`classify`]), which are read-only.
+//! safe assumption is to gate them. The exceptions are the query tools of the
+//! two baked-in servers — the official sigit.si server and the smbCloud CLI —
+//! which are read-only (see [`classify`]).
 //!
 //! Session state (grants + plan mode) lives in a process-global keyed by
 //! session id — the same pattern as `mcp.rs`'s server cache — so the ACP
@@ -94,10 +95,14 @@ pub enum Decision {
 /// `tools.rs`'s `web_search` module doc for why it isn't classified by that
 /// `mcp__` prefix).
 ///
-/// One MCP exception: the *official* sigit.si server (`mcp__sigit__*`) is
-/// first-party, so its query tools — names starting `list_` or `get_`, plus
-/// `search_code` and `web_search` — are read-only and never prompt (the TUI's
-/// Repo tab depends on this). Every other `mcp__*` tool stays mutating.
+/// Two MCP exceptions, both baked-in first-party servers. The *official*
+/// sigit.si server's (`mcp__sigit__*`) query tools — names starting `list_`
+/// or `get_`, plus `search_code` and `web_search` — are read-only and never
+/// prompt (the TUI's Repo tab depends on this). The smbCloud CLI server's
+/// (`mcp__smbcloud__*`) read tools are exempted by an explicit allow-list
+/// rather than a name shape, since its names don't follow the `list_`/`get_`
+/// convention — a tool the list doesn't know (e.g. from a newer smb) fails
+/// safe to mutating. Every other `mcp__*` tool stays mutating.
 pub fn classify(tool_name: &str) -> ToolRisk {
     match tool_name {
         "read_file" | "list_directory" | "search_files" | "glob" | "read_website"
@@ -108,6 +113,11 @@ pub fn classify(tool_name: &str) -> ToolRisk {
                     || bare.starts_with("get_")
                     || bare == "search_code"
                     || bare == "web_search")
+            {
+                return ToolRisk::ReadOnly;
+            }
+            if let Some(bare) = crate::mcp::smbcloud_tool_suffix(tool_name)
+                && matches!(bare, "me" | "deployments" | "project_list" | "project_show")
             {
                 return ToolRisk::ReadOnly;
             }
@@ -502,6 +512,42 @@ mod tests {
                 Decision::Allow,
                 "{tool}"
             );
+        }
+    }
+
+    #[test]
+    fn smbcloud_mcp_read_tools_are_read_only() {
+        let _guard = env_guard();
+        for tool in [
+            "mcp__smbcloud__me",
+            "mcp__smbcloud__deployments",
+            "mcp__smbcloud__project_list",
+            "mcp__smbcloud__project_show",
+        ] {
+            assert_eq!(classify(tool), ToolRisk::ReadOnly, "{tool}");
+            assert_eq!(
+                decision_for("t-smbcloud", tool, "{}"),
+                Decision::Allow,
+                "{tool}"
+            );
+        }
+    }
+
+    #[test]
+    fn smbcloud_mcp_mutating_and_unknown_tools_stay_gated() {
+        for tool in [
+            // smbcloud server, but not on the read allow-list
+            "mcp__smbcloud__project_create",
+            "mcp__smbcloud__project_update",
+            "mcp__smbcloud__project_delete",
+            "mcp__smbcloud__",
+            // allow-listed names on other servers get no exemption
+            "mcp__other__project_list",
+            "mcp__other__me",
+            // `smbcloud` must match the whole server name
+            "mcp__smbcloudx__project_list",
+        ] {
+            assert_eq!(classify(tool), ToolRisk::Mutating, "{tool}");
         }
     }
 


### PR DESCRIPTION
sigit already bakes in its official HTTP MCP server. This adds a second built-in entry: the smbCloud CLI's stdio server (`smb --mcp`), so smbCloud project and deployment tools (`mcp__smbcloud__project_list`, `deployments`, `me`, ...) work out of the box, with no `mcp.toml` setup.

## How it behaves

- The entry is only added when the `smb` binary is actually on `PATH` (checked with the platform's executable suffix, so `.exe` on Windows). Users without smbcloud-cli installed see nothing in `/mcp` instead of a spawn failure.
- A user-defined `mcp.toml` server named `smbcloud` overrides the baked-in one, same never-clobber rule as the official `sigit` entry.
- Opt out with `smbcloud = false` in `mcp.toml` or `SIGIT_MCP_SMBCLOUD=off`, mirroring `official = false` / `SIGIT_MCP_OFFICIAL`.
- Like the official server's query tools, smbcloud's read-only tools (`me`, `deployments`, `project_list`, `project_show`) run without a permission prompt. This uses an explicit allow-list rather than the official server's `list_`/`get_` name-shape check, so a tool the list doesn't know fails safe to mutating; `project_create`/`project_update`/`project_delete` stay behind the ask-by-default gate, and query-shaped names on foreign servers get no exemption.

## Testing

- `cargo fmt -- --check`, `cargo clippy --tests -- -D warnings`, and `cargo test --locked` are all green locally (237 tests, including new coverage for the opt-out flag, the PATH probe, the namespace suffix helper, and the read-only classification).
- Smoke-tested the real server: piped an `initialize`/`tools/list` handshake into `smb --mcp` over stdio and got the expected 7 tools back, confirming it speaks the newline-delimited JSON-RPC framing sigit's stdio client expects.