### PR TITLE
acp: emit ToolCall events for every tool execution; send tool_choice auto

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -459,6 +459,12 @@ impl OpenAiBackend {
             && !tools.is_empty()
         {
             body["tools"] = serde_json::Value::Array(Self::tools_json(tools));
+            // OpenAI specifies `auto` as the default when tools are present,
+            // but not every OpenAI-compatible gateway implements that default.
+            // Sending it explicitly is important for the cloud path: otherwise
+            // a model can describe the action it intends to take as text and
+            // end the turn without returning a tool call at all.
+            body["tool_choice"] = serde_json::Value::String("auto".to_string());
         }
 
         let response = self

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -186,13 +186,19 @@ pub(crate) fn tool_title(name: &str, arguments_json: &str) -> String {
 }
 
 /// Pretty-print a tool call's JSON arguments for the expanded view; malformed
-/// JSON is shown raw.
+/// JSON is logged and shown raw.
 #[cfg_attr(not(unix), allow(dead_code))]
 pub(crate) fn pretty_tool_arguments(arguments_json: &str) -> String {
-    serde_json::from_str::<serde_json::Value>(arguments_json)
-        .ok()
-        .and_then(|value| serde_json::to_string_pretty(&value).ok())
-        .unwrap_or_else(|| arguments_json.to_string())
+    match serde_json::from_str::<serde_json::Value>(arguments_json) {
+        Ok(value) => serde_json::to_string_pretty(&value).unwrap_or_else(|e| {
+            log::warn!("failed to pretty-print tool arguments: {e}");
+            arguments_json.to_string()
+        }),
+        Err(e) => {
+            log::warn!("malformed JSON in tool arguments: {e}");
+            arguments_json.to_string()
+        }
+    }
 }
 
 /// The tail of a tool's output for display under an expanded tool entry,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1515,6 +1515,27 @@ impl SiGitAgent {
                     tc.arguments.chars().take(120).collect::<String>()
                 );
 
+                // Model tool calls are agent actions in ACP too, not merely an
+                // implementation detail of the completion loop. Announce each
+                // one before it runs and close it afterwards so clients such as
+                // Zed can render activity while the next inference round is in
+                // flight. Previously only model loading emitted ToolCall events,
+                // leaving an otherwise working tool round visually indistinct
+                // from a stalled response.
+                let raw_input: serde_json::Value = serde_json::from_str(&tc.arguments)
+                    .unwrap_or_else(|_| serde_json::Value::String(tc.arguments.clone()));
+                self.send_tool_call_update(
+                    cx,
+                    session_id.clone(),
+                    SessionUpdate::ToolCall(
+                        ToolCall::new(tc.id.clone(), tc.name.clone())
+                            .kind(tool_kind_for(&tc.name))
+                            .status(ToolCallStatus::InProgress)
+                            .raw_input(raw_input),
+                    ),
+                )
+                .ok();
+
                 let signature = format!("{}\n{}", tc.name, tc.arguments);
                 let repeat_count = repeated_tool_calls
                     .entry(signature)
@@ -1585,6 +1606,20 @@ impl SiGitAgent {
                                             ),
                                         });
                                     }
+                                    self.send_tool_call_update(
+                                        cx,
+                                        session_id.clone(),
+                                        SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                                            tc.id.clone(),
+                                            ToolCallUpdateFields::new()
+                                                .status(ToolCallStatus::Failed)
+                                                .raw_output(serde_json::Value::String(
+                                                    "Not executed: the user cancelled the turn at the permission prompt."
+                                                        .to_string(),
+                                                )),
+                                        )),
+                                    )
+                                    .ok();
                                     backend.record_cancelled_tool_results(tool_results).await;
                                     return Ok(PromptResponse::new(StopReason::Cancelled));
                                 }
@@ -1594,6 +1629,18 @@ impl SiGitAgent {
                 };
 
                 log::info!("  ← {} chars", output.len());
+
+                self.send_tool_call_update(
+                    cx,
+                    session_id.clone(),
+                    SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                        tc.id.clone(),
+                        ToolCallUpdateFields::new()
+                            .status(ToolCallStatus::Completed)
+                            .raw_output(serde_json::Value::String(output.clone())),
+                    )),
+                )
+                .ok();
 
                 tool_results.push(BackendToolResult {
                     tool_call_id: tc.id.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1523,7 +1523,10 @@ impl SiGitAgent {
                 // leaving an otherwise working tool round visually indistinct
                 // from a stalled response.
                 let raw_input: serde_json::Value = serde_json::from_str(&tc.arguments)
-                    .unwrap_or_else(|_| serde_json::Value::String(tc.arguments.clone()));
+                    .unwrap_or_else(|e| {
+                        log::warn!("malformed JSON in tool arguments for '{}': {e}", tc.name);
+                        serde_json::Value::String(tc.arguments.clone())
+                    });
                 self.send_tool_call_update(
                     cx,
                     session_id.clone(),
@@ -1734,8 +1737,10 @@ impl SiGitAgent {
         } else {
             format!("{tool_name}({args_preview})")
         };
-        let raw_input: serde_json::Value = serde_json::from_str(arguments)
-            .unwrap_or_else(|_| serde_json::Value::String(arguments.to_string()));
+        let raw_input: serde_json::Value = serde_json::from_str(arguments).unwrap_or_else(|e| {
+            log::warn!("malformed JSON in tool arguments for '{}': {e}", tool_name);
+            serde_json::Value::String(arguments.to_string())
+        });
 
         let request = RequestPermissionRequest::new(
             session_id.clone(),

--- a/tests/acp_permissions.rs
+++ b/tests/acp_permissions.rs
@@ -316,6 +316,12 @@ fn permission_round_trip_cancel_then_allow() {
     let requests = endpoint.requests.lock().unwrap();
     assert_eq!(requests.len(), 3, "expected exactly three completions");
 
+    // The client explicitly requests automatic tool selection. Some
+    // OpenAI-compatible gateways do not honour OpenAI's implicit `auto`
+    // default, which otherwise lets the model describe a tool action in prose
+    // and end the turn without a tool call.
+    assert_eq!(requests[0]["tool_choice"], "auto");
+
     // Request 2 replays the full history: the cancelled round's tool call
     // must be answered by a `role: "tool"` message, not left dangling.
     let messages = requests[1]["messages"].as_array().expect("messages");


### PR DESCRIPTION
Clients such as Zed had no visibility into tool activity between inference rounds — only model loading emitted ToolCall events. Now the agent loop sends ToolCall(InProgress) before each tool runs and ToolCallUpdate with Completed or Failed (including the cancelled-at-permission-prompt case) after it returns.

Also send `tool_choice: "auto"` explicitly whenever tools are present. OpenAI's spec says auto is the default, but not every compatible gateway implements that default — without it some models describe the intended action in prose and end the turn without a tool call.

Test coverage: assert tool_choice is present in acp_permissions.