### PR TITLE
fix: render nfpm config with envsubst so deb/rpm builds succeed

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -141,8 +141,41 @@ jobs:
           export PKG_VERSION="${RELEASE_VERSION}"
           export PKG_BINARY="./release/${PROJECT_NAME}-${{ matrix.name }}"
 
-          /tmp/nfpm package --config packaging/nfpm.yaml --packager deb --target ./release/
-          /tmp/nfpm package --config packaging/nfpm.yaml --packager rpm --target ./release/
+          # An empty version is worse than a hard failure here: nfpm accepts it
+          # and silently emits a "0.0.0~rc0" package that would be attached to
+          # the release. Same for a missing binary, which only surfaces as an
+          # opaque glob error. Fail loudly instead.
+          if [ -z "${PKG_VERSION}" ]; then
+            echo "RELEASE_VERSION is empty; refusing to build packages" >&2
+            exit 1
+          fi
+          if [ ! -f "${PKG_BINARY}" ]; then
+            echo "Staged binary ${PKG_BINARY} not found" >&2
+            exit 1
+          fi
+
+          # nfpm expands ${VAR} in most fields but NOT in contents.src, so the
+          # config is rendered up front and nfpm only ever sees literal values.
+          # envsubst comes from gettext-base, preinstalled on the Ubuntu runner
+          # images. The explicit variable list keeps it from clobbering any
+          # other shell-looking text added to the config later.
+          if ! command -v envsubst >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y gettext-base
+          fi
+
+          envsubst '${PKG_ARCH} ${PKG_VERSION} ${PKG_BINARY}' \
+            < packaging/nfpm.yaml > /tmp/nfpm.rendered.yaml
+
+          /tmp/nfpm package --config /tmp/nfpm.rendered.yaml --packager deb --target ./release/
+          /tmp/nfpm package --config /tmp/nfpm.rendered.yaml --packager rpm --target ./release/
+
+          # Guard against a packager silently producing nothing.
+          for ext in deb rpm; do
+            if ! compgen -G "./release/*.${ext}" >/dev/null; then
+              echo "No .${ext} produced" >&2
+              exit 1
+            fi
+          done
 
           ls -la ./release/
 

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -7,7 +7,9 @@
 # config.
 #
 # PKG_ARCH and PKG_VERSION are set by release-github.yml; PKG_BINARY points at
-# the renamed binary already staged in release/.
+# the renamed binary already staged in release/. nfpm does not expand env vars
+# in contents.src, so release-github.yml renders this file with envsubst before
+# invoking nfpm.
 name: sigit
 arch: ${PKG_ARCH}
 platform: linux


### PR DESCRIPTION
The Linux jobs in release-github failed at "Build Linux packages" with:

glob failed: ${PKG_BINARY}: no matching files

nfpm expands ${VAR} in scalar fields such as arch: and version:, but not in contents[].src (goreleaser/nfpm#719), so the staged binary path was passed through literally and matched nothing. Both Linux targets died there, which blocked the release job and the Homebrew/Scoop/winget fan-out that depends on it.

Render packaging/nfpm.yaml through envsubst first so nfpm only ever sees literal values. envsubst is restricted to the three known variables so it cannot clobber shell-looking text (scriptlets, $PATH) added to the config later.

Also guard against a worse, silent failure found while verifying this: when RELEASE_VERSION is empty nfpm exits 0 and emits a bogus "sigit_0.0.0~rc0_amd64.deb" that would be attached to the release. The step now fails loudly on an empty version or a missing binary, and verifies both packagers actually produced output.

Verified against nfpm 2.43.0 (the pinned CI version): amd64 and arm64 both produce correctly named deb/rpm artifacts containing /usr/bin/sigit at 0755 root:root.