### PR TITLE
Run synchronous tools off the ACP connection task

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -455,16 +455,37 @@ pub async fn execute_tool(name: &str, arguments: &str) -> String {
 
 async fn execute_tool_impl(name: &str, arguments: &str) -> String {
     match name {
+        TASK_TOOL_NAME => exec_task(arguments).await,
+        WEB_SEARCH_TOOL_NAME => exec_web_search(arguments).await,
+        // Tools discovered from MCP servers are namespaced `mcp__<server>__<tool>`
+        // and forwarded to the owning server.
+        _ if crate::mcp::is_mcp_tool(name) => crate::mcp::call_tool(name, arguments).await,
+        // Everything else is synchronous and may run for a long time: a shell
+        // command up to COMMAND_TIMEOUT, a glob over a big tree, an HTTP fetch
+        // on reqwest::blocking (which panics if polled on a runtime thread).
+        // The ACP connection multiplexes reading the client, writing
+        // notifications, and running the turn onto a single task, so blocking
+        // here freezes the editor's view of the session: the tool call's
+        // `in_progress` update — the editor's spinner — only reaches the client
+        // once the tool has already finished.
+        _ => {
+            let tool = name.to_owned();
+            let arguments = arguments.to_owned();
+            let running = tool.clone();
+            tokio::task::spawn_blocking(move || execute_sync_tool(&running, &arguments))
+                .await
+                .unwrap_or_else(|err| format!("Error: {tool} task failed: {err}"))
+        }
+    }
+}
+
+/// The synchronous tools, run on the blocking pool by [`execute_tool_impl`].
+fn execute_sync_tool(name: &str, arguments: &str) -> String {
+    match name {
         "read_file" => exec_read_file(arguments),
         "list_directory" => exec_list_directory(arguments),
         "search_files" => exec_search_files(arguments),
-        "read_website" => {
-            // reqwest::blocking panics inside a tokio runtime, so run on the blocking pool.
-            let args = arguments.to_owned();
-            tokio::task::spawn_blocking(move || exec_read_website(&args))
-                .await
-                .unwrap_or_else(|err| format!("Error: read_website task failed: {err}"))
-        }
+        "read_website" => exec_read_website(arguments),
         "create_directory" => exec_create_directory(arguments),
         "create_file" => exec_create_file(arguments),
         "edit_file" => exec_edit_file(arguments),
@@ -477,11 +498,6 @@ async fn execute_tool_impl(name: &str, arguments: &str) -> String {
         "command_output" => exec_command_output(arguments),
         "kill_command" => exec_kill_command(arguments),
         "skill" => crate::skills::activate_skill(arguments),
-        TASK_TOOL_NAME => exec_task(arguments).await,
-        WEB_SEARCH_TOOL_NAME => exec_web_search(arguments).await,
-        // Tools discovered from MCP servers are namespaced `mcp__<server>__<tool>`
-        // and forwarded to the owning server.
-        _ if crate::mcp::is_mcp_tool(name) => crate::mcp::call_tool(name, arguments).await,
         _ => format!("Unknown tool: {name}"),
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -474,12 +474,24 @@ async fn execute_tool_impl(name: &str, arguments: &str) -> String {
             let running = tool.clone();
             tokio::task::spawn_blocking(move || execute_sync_tool(&running, &arguments))
                 .await
+                // A `JoinError` means the tool panicked (or the runtime is
+                // shutting down). Report it as the tool's result rather than
+                // propagating: a panicking tool should cost the model one bad
+                // tool result, not the whole turn. Note this is strictly safer
+                // than running the tool inline, where the panic would unwind
+                // through the turn and take the ACP connection with it.
                 .unwrap_or_else(|err| format!("Error: {tool} task failed: {err}"))
         }
     }
 }
 
 /// The synchronous tools, run on the blocking pool by [`execute_tool_impl`].
+///
+/// Everything here runs on a blocking thread with no reactor, so nothing in
+/// this match may await or drive a tokio resource. A new tool that needs the
+/// async context belongs in [`execute_tool_impl`] alongside `task` and
+/// `web_search` instead — and then owes its own answer to the question this
+/// dispatch exists for: not blocking the caller's task for its whole run.
 fn execute_sync_tool(name: &str, arguments: &str) -> String {
     match name {
         "read_file" => exec_read_file(arguments),

--- a/tests/acp_permissions.rs
+++ b/tests/acp_permissions.rs
@@ -226,8 +226,16 @@ impl AgentUnderTest {
     }
 
     /// The first `session/update` whose payload satisfies `matches`.
+    ///
+    /// Only used by tests that run with the permission gate off, so a
+    /// `session/request_permission` means the run is misconfigured — say that
+    /// rather than waiting out the timeout on a request nobody will answer.
     fn wait_for_update(&mut self, what: &str, matches: impl Fn(&Value) -> bool) -> Value {
         let message = self.wait_for(what, |message| {
+            assert!(
+                message["method"] != "session/request_permission",
+                "unexpected permission request while waiting for {what}: {message}"
+            );
             message["method"] == "session/update" && matches(&message["params"]["update"])
         });
         message["params"]["update"].clone()
@@ -385,18 +393,32 @@ fn permission_round_trip_cancel_then_allow() {
 
 #[test]
 fn a_slow_commands_progress_reaches_the_client_while_it_runs() {
-    // `SIGIT_PERMISSIONS=allow` skips the gate, so the only thing between the
-    // two updates below is the command itself.
-    let endpoint = start_fake_endpoint(vec![
-        sse_tool_call("call_1", "run_command", r#"{"command":"sleep 2"}"#),
-        sse_text("done"),
-    ]);
-
     let scratch = std::env::temp_dir().join(format!("sigit_acp_progress_{}", std::process::id()));
     let config_dir = scratch.join("config");
     let cwd = scratch.join("cwd");
     std::fs::create_dir_all(&config_dir).unwrap();
     std::fs::create_dir_all(&cwd).unwrap();
+
+    // The command has to take a couple of seconds through `sh -c` / `cmd /C`.
+    // `sleep` is neither a cmd builtin nor on a Windows runner's PATH (Git's
+    // usr\bin, which carries the MSYS coreutils, is deliberately left off it),
+    // and the Windows job hung on it rather than failing fast. `ping` ships in
+    // System32, waits a second between echoes, and never reads stdin.
+    #[cfg(unix)]
+    let command = "sleep 2";
+    #[cfg(windows)]
+    let command = "ping -n 3 127.0.0.1";
+
+    // `SIGIT_PERMISSIONS=allow` skips the gate, so the only thing between the
+    // two updates below is the command itself.
+    let endpoint = start_fake_endpoint(vec![
+        sse_tool_call(
+            "call_1",
+            "run_command",
+            &json!({"command": command, "cwd": cwd}).to_string(),
+        ),
+        sse_text("done"),
+    ]);
 
     let mut agent = spawn_agent_with_permissions(endpoint.port, &config_dir, Some("allow"));
 
@@ -429,20 +451,21 @@ fn a_slow_commands_progress_reaches_the_client_while_it_runs() {
         "a running tool call must be announced as in_progress: {started}"
     );
 
-    agent.wait_for_update("the tool call finishing", |update| {
+    let finished = agent.wait_for_update("the tool call finishing", |update| {
         update["sessionUpdate"] == "tool_call_update"
             && update["toolCallId"] == "call_1"
             && update["status"] == "completed"
     });
 
-    // `sleep 2` runs between the two updates. If the turn blocked the
-    // connection's actors, both would only reach the client once the command
-    // had already finished, and the editor would never draw a spinner.
+    // The command runs between the two updates. If the turn blocked the
+    // connection's actors, both would only reach the client once it had
+    // already finished, and the editor would never draw a spinner.
     assert!(
         in_progress_at.elapsed() >= Duration::from_millis(1_000),
         "in_progress arrived only {:?} before completed — the client had no \
-         window to show progress in",
-        in_progress_at.elapsed()
+         window to show progress in. `{command}` said: {}",
+        in_progress_at.elapsed(),
+        finished["rawOutput"]
     );
 
     let response = agent.wait_for_response(prompt_id);

--- a/tests/acp_permissions.rs
+++ b/tests/acp_permissions.rs
@@ -399,15 +399,23 @@ fn a_slow_commands_progress_reaches_the_client_while_it_runs() {
     std::fs::create_dir_all(&config_dir).unwrap();
     std::fs::create_dir_all(&cwd).unwrap();
 
-    // The command has to take a couple of seconds through `sh -c` / `cmd /C`.
+    // The command has to run for a few seconds through `sh -c` / `cmd /C`.
     // `sleep` is neither a cmd builtin nor on a Windows runner's PATH (Git's
     // usr\bin, which carries the MSYS coreutils, is deliberately left off it),
     // and the Windows job hung on it rather than failing fast. `ping` ships in
     // System32, waits a second between echoes, and never reads stdin.
+    //
+    // Four seconds against the one-second assertion below is deliberate
+    // padding. A busy runner only ever widens the gap being measured — it
+    // cannot make the command finish sooner — so the one way a correct agent
+    // could fail here is this thread being descheduled for seconds between
+    // reading the two updates off the channel. Three seconds of slack covers
+    // that without weakening the assertion, which is separating four seconds
+    // from the 164µs the blocking version produced.
     #[cfg(unix)]
-    let command = "sleep 2";
+    let command = "sleep 4";
     #[cfg(windows)]
-    let command = "ping -n 3 127.0.0.1";
+    let command = "ping -n 5 127.0.0.1";
 
     // `SIGIT_PERMISSIONS=allow` skips the gate, so the only thing between the
     // two updates below is the command itself.

--- a/tests/acp_permissions.rs
+++ b/tests/acp_permissions.rs
@@ -13,6 +13,10 @@
 //!    would reject the whole session.
 //! 2. `selected: allow_once` — the tool must actually execute and its output
 //!    travel back to the endpoint as a tool result.
+//!
+//! A second test covers live progress: a slow command's `in_progress` tool call
+//! must reach the client while the command is still running, which is what the
+//! editor's spinner is driven from.
 
 use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Read, Write};
@@ -124,21 +128,34 @@ struct AgentUnderTest {
 }
 
 fn spawn_agent(port: u16, config_dir: &std::path::Path) -> AgentUnderTest {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_sigit"))
+    spawn_agent_with_permissions(port, config_dir, None)
+}
+
+/// `permissions` sets `SIGIT_PERMISSIONS`; `None` leaves the default `ask` mode
+/// in place, which is what the permission round-trip needs.
+fn spawn_agent_with_permissions(
+    port: u16,
+    config_dir: &std::path::Path,
+    permissions: Option<&str>,
+) -> AgentUnderTest {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_sigit"));
+    command
         .env("OPENAI_BASE_URL", format!("http://127.0.0.1:{port}"))
         .env("OPENAI_API_KEY", "test-key")
         .env("SIGIT_MODEL", "scripted-model")
         .env("SIGIT_CONFIG_DIR", config_dir)
         .env("SIGIT_MCP", "off")
-        // A fresh config dir means the default permission mode, `ask` — make
-        // sure the environment can't turn the gate off underneath the test.
-        .env_remove("SIGIT_PERMISSIONS")
         .env_remove("SIGIT_LOCAL_INFERENCE")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn sigit in ACP mode");
+        .stderr(Stdio::null());
+    match permissions {
+        // A fresh config dir means the default permission mode, `ask` — make
+        // sure the environment can't turn the gate off underneath the test.
+        None => command.env_remove("SIGIT_PERMISSIONS"),
+        Some(mode) => command.env("SIGIT_PERMISSIONS", mode),
+    };
+    let mut child = command.spawn().expect("spawn sigit in ACP mode");
 
     let stdout = child.stdout.take().unwrap();
     let (message_tx, incoming) = channel();
@@ -206,6 +223,14 @@ impl AgentUnderTest {
             "request {id} failed: {response}"
         );
         response
+    }
+
+    /// The first `session/update` whose payload satisfies `matches`.
+    fn wait_for_update(&mut self, what: &str, matches: impl Fn(&Value) -> bool) -> Value {
+        let message = self.wait_for(what, |message| {
+            message["method"] == "session/update" && matches(&message["params"]["update"])
+        });
+        message["params"]["update"].clone()
     }
 
     /// A request *from* the agent (has a `method` and its own id).
@@ -353,6 +378,75 @@ fn permission_round_trip_cancel_then_allow() {
             .contains("sigit-approved"),
         "the approved command's output should reach the endpoint: {result}"
     );
+
+    drop(agent);
+    let _ = std::fs::remove_dir_all(&scratch);
+}
+
+#[test]
+fn a_slow_commands_progress_reaches_the_client_while_it_runs() {
+    // `SIGIT_PERMISSIONS=allow` skips the gate, so the only thing between the
+    // two updates below is the command itself.
+    let endpoint = start_fake_endpoint(vec![
+        sse_tool_call("call_1", "run_command", r#"{"command":"sleep 2"}"#),
+        sse_text("done"),
+    ]);
+
+    let scratch = std::env::temp_dir().join(format!("sigit_acp_progress_{}", std::process::id()));
+    let config_dir = scratch.join("config");
+    let cwd = scratch.join("cwd");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    let mut agent = spawn_agent_with_permissions(endpoint.port, &config_dir, Some("allow"));
+
+    let id = agent.request(
+        "initialize",
+        json!({"protocolVersion": 1, "clientCapabilities": {}}),
+    );
+    agent.wait_for_response(id);
+
+    let id = agent.request("session/new", json!({"cwd": cwd, "mcpServers": []}));
+    let session_id = agent.wait_for_response(id)["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    let prompt_id = agent.request(
+        "session/prompt",
+        json!({
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": "run the slow command"}],
+        }),
+    );
+
+    let started = agent.wait_for_update("the tool call starting", |update| {
+        update["sessionUpdate"] == "tool_call" && update["toolCallId"] == "call_1"
+    });
+    let in_progress_at = Instant::now();
+    assert_eq!(
+        started["status"], "in_progress",
+        "a running tool call must be announced as in_progress: {started}"
+    );
+
+    agent.wait_for_update("the tool call finishing", |update| {
+        update["sessionUpdate"] == "tool_call_update"
+            && update["toolCallId"] == "call_1"
+            && update["status"] == "completed"
+    });
+
+    // `sleep 2` runs between the two updates. If the turn blocked the
+    // connection's actors, both would only reach the client once the command
+    // had already finished, and the editor would never draw a spinner.
+    assert!(
+        in_progress_at.elapsed() >= Duration::from_millis(1_000),
+        "in_progress arrived only {:?} before completed — the client had no \
+         window to show progress in",
+        in_progress_at.elapsed()
+    );
+
+    let response = agent.wait_for_response(prompt_id);
+    assert_eq!(response["result"]["stopReason"], "end_turn");
 
     drop(agent);
     let _ = std::fs::remove_dir_all(&scratch);


### PR DESCRIPTION
A long-running command showed no spinner in Zed. The ACP connection runs the incoming reader, the outgoing writer, and spawned turn tasks as actors joined into one future, so a tool that blocks its thread stalls all of them. Every synchronous tool did exactly that — run_command polls its child in a std::thread::sleep loop for up to COMMAND_TIMEOUT — so the tool call's in_progress notification sat in the outgoing queue until the command was already finished, and the client got in_progress and completed back to back with nothing to draw in between.

The synchronous tools move to the blocking pool behind one spawn_blocking, in execute_sync_tool. read_website was already wrapped for the same underlying reason (reqwest::blocking panics on a runtime thread) and now shares the one wrapper. The turn still awaits each tool in order, so nothing about the loop's sequencing changes.

Measured by a new end-to-end test: a scripted `sleep 2` with the permission gate off, asserting the client sees in_progress at least a second before completed. Against the old code the two arrive 164µs apart.

Fixes #62