### PR TITLE
Break the paragraph between tool rounds

### DIFF
--- a/src/headless.rs
+++ b/src/headless.rs
@@ -228,16 +228,12 @@ async fn run_prompt(
     // sink is passed and only the final message is printed.
     let (sink, mut sink_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
     let sink_opt = if config.quiet { None } else { Some(&sink) };
-    let mut assembled = String::new();
-    let mut sent = String::new();
-    let mut streamed_any = false;
+    let mut reply = crate::StreamedReply::default();
 
     let mut result = drain_to_stdout(
         backend.send_message_with_tools(&config.prompt, &tools, sink_opt),
         &mut sink_rx,
-        &mut assembled,
-        &mut sent,
-        &mut streamed_any,
+        &mut reply,
     )
     .await?;
 
@@ -300,12 +296,14 @@ async fn run_prompt(
             None // last round: force text
         };
 
+        // Whatever this round says starts a new paragraph rather than
+        // continuing the sentence the tool calls interrupted.
+        reply.interrupt();
+
         result = drain_to_stdout(
             backend.send_tool_results(tool_results, next_tools, sink_opt),
             &mut sink_rx,
-            &mut assembled,
-            &mut sent,
-            &mut streamed_any,
+            &mut reply,
         )
         .await?;
     }
@@ -318,7 +316,7 @@ async fn run_prompt(
         if !final_visible.is_empty() {
             let _ = writeln!(stdout, "{final_visible}");
         }
-    } else if streamed_any {
+    } else if reply.streamed_any {
         // The reply is already on stdout; end the line for the shell.
         let _ = writeln!(stdout);
     } else if !final_visible.is_empty() {
@@ -335,9 +333,7 @@ async fn run_prompt(
 async fn drain_to_stdout<F>(
     fut: F,
     sink_rx: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
-    assembled: &mut String,
-    sent: &mut String,
-    streamed_any: &mut bool,
+    reply: &mut crate::StreamedReply,
 ) -> Result<TurnResult, backend::BackendError>
 where
     F: std::future::Future<Output = Result<TurnResult, backend::BackendError>>,
@@ -347,39 +343,23 @@ where
         tokio::select! {
             done = &mut fut => break done,
             Some(piece) = sink_rx.recv() => {
-                emit_visible_chunk(&piece, assembled, sent, streamed_any);
+                emit_visible_chunk(&piece, reply);
             }
         }
     };
     // Flush tokens that landed between the last poll and the future resolving.
     while let Ok(piece) = sink_rx.try_recv() {
-        emit_visible_chunk(&piece, assembled, sent, streamed_any);
+        emit_visible_chunk(&piece, reply);
     }
     result
 }
 
-/// Append a streamed fragment, strip `<think>` reasoning from the running
-/// text, and print only the newly revealed visible suffix. Tracking the
-/// assembled text (not just deltas) keeps think-block stripping correct even
-/// when a tag spans chunk boundaries — same approach as the ACP path.
-fn emit_visible_chunk(
-    piece: &str,
-    assembled: &mut String,
-    sent: &mut String,
-    streamed_any: &mut bool,
-) {
-    assembled.push_str(piece);
-    let (_think, visible) = crate::chat::strip_think_blocks(assembled);
-    match visible.strip_prefix(sent.as_str()) {
-        Some(extra) if !extra.is_empty() => {
-            print!("{extra}");
-            let _ = std::io::stdout().flush();
-            *sent = visible;
-            *streamed_any = true;
-        }
-        // No new visible text, or the visible prefix changed retroactively
-        // (rare, e.g. a late-closing think tag): resync without reprinting.
-        _ => *sent = visible,
+/// Fold a streamed fragment into `reply` and print whatever it newly reveals —
+/// the stdio counterpart of `SiGitAgent::emit_visible_chunk`.
+fn emit_visible_chunk(piece: &str, reply: &mut crate::StreamedReply) {
+    if let Some(extra) = reply.push(piece) {
+        print!("{extra}");
+        let _ = std::io::stdout().flush();
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,6 +248,77 @@ pub(crate) fn system_prompt_for_model(tool_calling: bool) -> &'static str {
 /// context window, so the cap can afford to be generous
 const MAX_TOOL_ROUNDS: usize = 24;
 
+/// Separator between two stretches of assistant prose that a tool round split
+/// apart. ACP clients concatenate consecutive agent-message chunks into a
+/// single block, so a plain newline (or nothing at all) leaves the rounds
+/// reading as one run-on paragraph.
+const PARAGRAPH_BREAK: &str = "\n\n";
+
+/// The assistant reply being streamed over the course of one prompt, tracked
+/// across every tool round so `<think>` stripping stays correct and no text is
+/// sent twice.
+#[derive(Default)]
+struct StreamedReply {
+    /// Raw text as it arrives, reasoning tags included: think-block stripping
+    /// needs the whole string, since a tag can span chunk boundaries.
+    assembled: String,
+    /// The visible text already on the wire.
+    sent: String,
+    /// Whether any chunk has been sent, i.e. the client already has a reply.
+    streamed_any: bool,
+    /// Whether the next visible text should open a new paragraph.
+    paragraph_pending: bool,
+}
+
+impl StreamedReply {
+    /// Record that a tool round has interrupted the prose, so the next chunk
+    /// starts a paragraph. A round that opened with tool calls and no text has
+    /// no sentence to break away from, hence the `streamed_any` guard.
+    fn interrupt(&mut self) {
+        self.paragraph_pending = self.streamed_any;
+    }
+
+    /// Fold one streamed fragment into the reply and return the visible text it
+    /// newly reveals, or `None` when it reveals nothing to show (it landed
+    /// inside a `<think>` block, say).
+    fn push(&mut self, piece: &str) -> Option<String> {
+        if self.paragraph_pending {
+            // A tool round interrupted the prose. Clients concatenate
+            // consecutive agent-message chunks into one block, so the new round
+            // has to open a paragraph or it runs onto the end of the previous
+            // sentence ("…parsed with unwrap_or_else.Let me broaden the
+            // search:"). Whatever whitespace the model puts at the seam gives
+            // way to the break.
+            let piece = piece.trim_start();
+            if piece.is_empty() {
+                return None;
+            }
+            self.assembled.push_str(PARAGRAPH_BREAK);
+            self.assembled.push_str(piece);
+            self.paragraph_pending = false;
+        } else {
+            self.assembled.push_str(piece);
+        }
+
+        let (_think, visible) = chat::strip_think_blocks(&self.assembled);
+        match visible.strip_prefix(self.sent.as_str()) {
+            Some(extra) if !extra.is_empty() => {
+                let extra = extra.to_string();
+                self.sent = visible;
+                self.streamed_any = true;
+                Some(extra)
+            }
+            // No new visible text, or the visible prefix changed retroactively
+            // (rare, e.g. a late-closing think tag): just resync without
+            // resending what's already on the wire.
+            _ => {
+                self.sent = visible;
+                None
+            }
+        }
+    }
+}
+
 /// Outcome of asking the client for permission to run one tool call.
 enum PermissionVerdict {
     /// Run the tool.
@@ -728,18 +799,15 @@ impl SiGitAgent {
     /// tokens to the editor. The sink receiver is drained as the future runs, so
     /// chunks reach the client live rather than all at once when it resolves.
     ///
-    /// `assembled`/`sent`/`streamed_any` persist across the turns of a single
-    /// prompt so reasoning is stripped consistently and we never re-send text.
-    #[allow(clippy::too_many_arguments)]
+    /// `reply` persists across the turns of a single prompt so reasoning is
+    /// stripped consistently and we never re-send text.
     async fn drain_turn<F>(
         &self,
         cx: &ConnectionTo<Client>,
         session_id: &SessionId,
         fut: F,
         sink_rx: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
-        assembled: &mut String,
-        sent: &mut String,
-        streamed_any: &mut bool,
+        reply: &mut StreamedReply,
     ) -> Result<TurnResult, backend::BackendError>
     where
         F: std::future::Future<Output = Result<TurnResult, backend::BackendError>>,
@@ -749,44 +817,29 @@ impl SiGitAgent {
             tokio::select! {
                 done = &mut fut => break done,
                 Some(piece) = sink_rx.recv() => {
-                    self.emit_visible_chunk(cx, session_id, &piece, assembled, sent, streamed_any);
+                    self.emit_visible_chunk(cx, session_id, &piece, reply);
                 }
             }
         };
         // Flush tokens that landed between the last poll and the future resolving.
         while let Ok(piece) = sink_rx.try_recv() {
-            self.emit_visible_chunk(cx, session_id, &piece, assembled, sent, streamed_any);
+            self.emit_visible_chunk(cx, session_id, &piece, reply);
         }
         result
     }
 
-    /// Append a streamed fragment, strip `<think>` reasoning from the running
-    /// text, and send only the newly revealed visible suffix as a chunk. Tracking
-    /// the assembled text (not just deltas) keeps think-block stripping correct
-    /// even when a tag spans chunk boundaries.
+    /// Fold a streamed fragment into `reply` and send whatever it newly reveals
+    /// as an agent-message chunk.
     fn emit_visible_chunk(
         &self,
         cx: &ConnectionTo<Client>,
         session_id: &SessionId,
         piece: &str,
-        assembled: &mut String,
-        sent: &mut String,
-        streamed_any: &mut bool,
+        reply: &mut StreamedReply,
     ) {
-        assembled.push_str(piece);
-        let (_think, visible) = chat::strip_think_blocks(assembled);
-        match visible.strip_prefix(sent.as_str()) {
-            Some(extra) if !extra.is_empty() => {
-                let extra = extra.to_string();
-                *sent = visible;
-                *streamed_any = true;
-                self.send_assistant_message(cx, session_id.clone(), extra)
-                    .ok();
-            }
-            // No new visible text, or the visible prefix changed retroactively
-            // (rare, e.g. a late-closing think tag): just resync without
-            // resending what's already on the wire.
-            _ => *sent = visible,
+        if let Some(extra) = reply.push(piece) {
+            self.send_assistant_message(cx, session_id.clone(), extra)
+                .ok();
         }
     }
 
@@ -1454,9 +1507,7 @@ impl SiGitAgent {
         // alive for the whole prompt so `recv()` only ends when a turn future
         // resolves, never because every sender was dropped.
         let (sink, mut sink_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-        let mut assembled = String::new();
-        let mut sent = String::new();
-        let mut streamed_any = false;
+        let mut reply = StreamedReply::default();
         let mut repeated_tool_calls = std::collections::HashMap::<String, usize>::new();
 
         let mut result = self
@@ -1465,9 +1516,7 @@ impl SiGitAgent {
                 &session_id,
                 backend.send_message_with_tools(&user_text, &tools, Some(&sink)),
                 &mut sink_rx,
-                &mut assembled,
-                &mut sent,
-                &mut streamed_any,
+                &mut reply,
             )
             .await
             .map_err(|error| {
@@ -1657,15 +1706,17 @@ impl SiGitAgent {
                 None // last round: force text
             };
 
+            // Whatever this round says starts a new paragraph rather than
+            // continuing the sentence the tool calls interrupted.
+            reply.interrupt();
+
             result = self
                 .drain_turn(
                     cx,
                     &session_id,
                     backend.send_tool_results(tool_results, next_tools, Some(&sink)),
                     &mut sink_rx,
-                    &mut assembled,
-                    &mut sent,
-                    &mut streamed_any,
+                    &mut reply,
                 )
                 .await
                 .map_err(|e| agent_client_protocol::Error::new(-32603, e.to_string()))?;
@@ -1675,7 +1726,7 @@ impl SiGitAgent {
         // If anything streamed, the visible reply is already on the wire; only
         // send a trailing block for the non-streamed path (e.g. on-device direct
         // answers, which onde can't stream while tools are on offer).
-        if !streamed_any {
+        if !reply.streamed_any {
             let reply_text = result.text.trim().to_string();
             let final_text = if reply_text.is_empty() {
                 if round > 0 {
@@ -3585,6 +3636,74 @@ async fn main() -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn streamed_reply_sends_each_fragment_as_it_is_revealed() {
+        let mut reply = StreamedReply::default();
+        assert_eq!(reply.push("Hello"), Some("Hello".to_string()));
+        assert_eq!(reply.push(", world"), Some(", world".to_string()));
+        assert!(reply.streamed_any);
+    }
+
+    #[test]
+    fn streamed_reply_opens_a_paragraph_after_a_tool_round() {
+        let mut reply = StreamedReply::default();
+        reply.push("I'll search for this pattern.");
+
+        // …tool calls run, then the next round starts talking again.
+        reply.interrupt();
+
+        assert_eq!(
+            reply.push("Let me broaden the search:"),
+            Some("\n\nLet me broaden the search:".to_string()),
+            "the new round must not run onto the end of the last sentence"
+        );
+        // Only the seam gets a break; the rest of the round streams as usual.
+        assert_eq!(reply.push(" Found them."), Some(" Found them.".to_string()));
+    }
+
+    #[test]
+    fn streamed_reply_drops_the_models_own_whitespace_at_the_seam() {
+        let mut reply = StreamedReply::default();
+        reply.push("Checking that.");
+        reply.interrupt();
+
+        // A fragment of pure whitespace reveals nothing and must not consume
+        // the pending break.
+        assert_eq!(reply.push("\n"), None);
+        assert_eq!(
+            reply.push("  Done."),
+            Some("\n\nDone.".to_string()),
+            "the break replaces the model's leading whitespace"
+        );
+    }
+
+    #[test]
+    fn streamed_reply_does_not_open_with_a_blank_paragraph() {
+        // First round was tool calls only, so nothing is on the wire yet and
+        // there is no sentence to break away from.
+        let mut reply = StreamedReply::default();
+        reply.interrupt();
+
+        assert_eq!(reply.push("Found them."), Some("Found them.".to_string()));
+    }
+
+    #[test]
+    fn streamed_reply_hides_reasoning_and_still_breaks_the_paragraph() {
+        let mut reply = StreamedReply::default();
+        reply.push("Looking now.");
+        reply.interrupt();
+
+        // A round that opens with reasoning reveals nothing until the visible
+        // text arrives — and that text still starts the new paragraph.
+        assert_eq!(reply.push("<think>weigh"), None);
+        assert_eq!(reply.push(" options</think>"), None);
+        assert_eq!(
+            reply.push("Here it is."),
+            Some("\n\nHere it is.".to_string()),
+            "the break waits for the reasoning to end and rides out with the text"
+        );
+    }
 
     #[test]
     fn explicit_acp_flag_is_accepted_without_other_arguments() {

--- a/tests/acp_permissions.rs
+++ b/tests/acp_permissions.rs
@@ -13,6 +13,10 @@
 //!    would reject the whole session.
 //! 2. `selected: allow_once` — the tool must actually execute and its output
 //!    travel back to the endpoint as a tool result.
+//!
+//! A second test covers what the client renders: text from two tool rounds must
+//! reach it as separate paragraphs, since ACP clients concatenate consecutive
+//! agent-message chunks into one block.
 
 use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Read, Write};
@@ -51,6 +55,21 @@ fn sse_tool_call(id: &str, name: &str, arguments: &str) -> String {
 
 fn sse_text(text: &str) -> String {
     sse_body(&[json!({"choices": [{"delta": {"content": text}}]})])
+}
+
+/// One round that says something and then asks for a tool — the shape that used
+/// to leave the next round's text glued to this sentence.
+fn sse_text_then_tool_call(text: &str, id: &str, name: &str, arguments: &str) -> String {
+    sse_body(&[
+        json!({"choices": [{"delta": {"content": text}}]}),
+        json!({
+            "choices": [{"delta": {"tool_calls": [{
+                "index": 0,
+                "id": id,
+                "function": {"name": name, "arguments": arguments},
+            }]}}]
+        }),
+    ])
 }
 
 /// Serves one scripted SSE response per request and records each request body.
@@ -208,6 +227,30 @@ impl AgentUnderTest {
         response
     }
 
+    /// The response to `session/prompt`, paired with every `agent_message_chunk`
+    /// seen on the way, concatenated exactly as a client renders them.
+    fn wait_for_prompt(&mut self, id: u64) -> (Value, String) {
+        let mut rendered = String::new();
+        let deadline = Instant::now() + TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let Ok(message) = self.incoming.recv_timeout(remaining) else {
+                panic!("timed out waiting for the prompt response");
+            };
+            let update = &message["params"]["update"];
+            if message["method"] == "session/update"
+                && update["sessionUpdate"] == "agent_message_chunk"
+                && let Some(chunk) = update["content"]["text"].as_str()
+            {
+                rendered.push_str(chunk);
+            }
+            if message["id"] == id && message.get("method").is_none() {
+                assert!(message.get("error").is_none(), "prompt failed: {message}");
+                return (message, rendered);
+            }
+        }
+    }
+
     /// A request *from* the agent (has a `method` and its own id).
     fn wait_for_agent_request(&mut self, method: &str) -> Value {
         self.wait_for(&format!("agent request {method}"), |message| {
@@ -352,6 +395,63 @@ fn permission_round_trip_cancel_then_allow() {
             .unwrap_or_default()
             .contains("sigit-approved"),
         "the approved command's output should reach the endpoint: {result}"
+    );
+
+    drop(agent);
+    let _ = std::fs::remove_dir_all(&scratch);
+}
+
+#[test]
+fn text_from_two_tool_rounds_reaches_the_client_as_separate_paragraphs() {
+    let endpoint = start_fake_endpoint(vec![
+        // `list_directory` is read-only, so it runs without a permission gate
+        // and the two rounds follow each other straight away.
+        sse_text_then_tool_call(
+            "I'll search for this pattern.",
+            "call_1",
+            "list_directory",
+            r#"{"path":"."}"#,
+        ),
+        sse_text("Let me broaden the search:"),
+    ]);
+
+    let scratch = std::env::temp_dir().join(format!("sigit_acp_spacing_{}", std::process::id()));
+    let config_dir = scratch.join("config");
+    let cwd = scratch.join("cwd");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    let mut agent = spawn_agent(endpoint.port, &config_dir);
+
+    let id = agent.request(
+        "initialize",
+        json!({"protocolVersion": 1, "clientCapabilities": {}}),
+    );
+    agent.wait_for_response(id);
+
+    let id = agent.request("session/new", json!({"cwd": cwd, "mcpServers": []}));
+    let session_id = agent.wait_for_response(id)["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    let prompt_id = agent.request(
+        "session/prompt",
+        json!({
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": "find it"}],
+        }),
+    );
+    let (response, rendered) = agent.wait_for_prompt(prompt_id);
+    assert_eq!(response["result"]["stopReason"], "end_turn");
+
+    assert!(
+        rendered.contains("pattern.\n\nLet me broaden"),
+        "the second round must open a new paragraph, got: {rendered:?}"
+    );
+    assert!(
+        !rendered.contains("pattern.Let me"),
+        "rounds must not run together into one sentence, got: {rendered:?}"
     );
 
     drop(agent);

--- a/tests/headless_mode.rs
+++ b/tests/headless_mode.rs
@@ -46,6 +46,21 @@ fn sse_text(text: &str) -> String {
     sse_body(&[json!({"choices": [{"delta": {"content": text}}]})])
 }
 
+/// One round that says something and then asks for a tool — the shape that used
+/// to leave the next round's text glued to this sentence.
+fn sse_text_then_tool_call(text: &str, id: &str, name: &str, arguments: &str) -> String {
+    sse_body(&[
+        json!({"choices": [{"delta": {"content": text}}]}),
+        json!({
+            "choices": [{"delta": {"tool_calls": [{
+                "index": 0,
+                "id": id,
+                "function": {"name": name, "arguments": arguments},
+            }]}}]
+        }),
+    ])
+}
+
 /// Serves one scripted SSE response per request and records each request body.
 struct FakeEndpoint {
     port: u16,
@@ -289,6 +304,50 @@ fn ask_level_tool_without_allow_flag_is_denied_but_run_completes() {
     assert!(
         !content.contains("must-not-run"),
         "the denied command must not have executed: {content}"
+    );
+}
+
+#[test]
+fn text_from_two_tool_rounds_is_not_run_together() {
+    let endpoint = start_fake_endpoint(vec![
+        sse_text_then_tool_call(
+            "I'll search for this pattern.",
+            "call_1",
+            "run_command",
+            r#"{"command":"echo first"}"#,
+        ),
+        sse_text("Let me broaden the search:"),
+    ]);
+    let scratch = scratch("spacing");
+    let cwd = scratch.cwd.to_str().unwrap().to_string();
+
+    let output = run_headless(
+        endpoint.port,
+        &scratch,
+        &[
+            "-p",
+            "find it",
+            "--allow-tool",
+            "run_command",
+            "--cwd",
+            &cwd,
+        ],
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("pattern.\n\nLet me broaden"),
+        "the second round must open a new paragraph, got: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("pattern.Let me"),
+        "rounds must not run together into one sentence, got: {stdout:?}"
     );
 }
 


### PR DESCRIPTION
Text from consecutive tool rounds arrived in Zed as one run-on block: "…parsed with unwrap_or_else.Let me broaden the search:Found them." Each round streams its own agent-message chunks, and ACP clients concatenate consecutive chunks, so round two picked up exactly where round one's last sentence ended.

The streaming bookkeeping (assembled text, what's already on the wire, whether anything streamed) moves into a StreamedReply that both the ACP and headless loops share, and the loops mark the seam when a tool round interrupts the prose. The next visible fragment then opens with a blank line, taking the model's own leading whitespace with it. A round that produced only tool calls has nothing to break away from, so a reply never starts with a stray blank line.

Covered end to end on both surfaces: a scripted two-round turn asserts the break reaches the client, and reverting the seam marker fails both tests with the run-on from the issue.

Fixes #55