### PR TITLE
Stop a re-pushed tag from failing the release

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -301,6 +301,14 @@ winget, and the AUR PKGBUILD each need one, and they consume the raw binaries ra
 tarball. `release-github` also builds a `.deb` and `.rpm` per Linux target with nfpm
 (`packaging/nfpm.yaml`), packaging the already-built binary rather than re-invoking cargo.
 
+Re-pushing a tag fires every release workflow a second time, so each one is grouped by tag in a
+`concurrency` block with `cancel-in-progress: false` — the duplicate queues behind the original
+rather than interrupting a publish that is halfway through uploading. What keeps the queued run
+from going red is the "is this version already published?" check each publishing workflow does
+before it uploads. Those checks are load-bearing, not belt-and-braces: v1.5.6 published twice
+because the crates.io one asked the API with curl's default User-Agent, which crates.io answers
+with a 403, which read as "not published yet".
+
 Three of these need credentials or a one-time manual step before they work:
 
 - Scoop needs a `getsigit/scoop-bucket` repo and a `SCOOP_BUCKET_TOKEN` secret, mirroring the

--- a/.github/workflows/release-aur.yml
+++ b/.github/workflows/release-aur.yml
@@ -12,6 +12,14 @@ on:
         description: "Release tag (e.g. v1.5.2)"
         required: true
 
+concurrency:
+  # A re-pushed or re-dispatched tag fires this a second time. Queue the
+  # duplicate behind the original instead of cancelling it: cancelling a run
+  # mid-publish can leave a channel half-uploaded, whereas a queued duplicate
+  # just hits the "already published" check and exits clean.
+  group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -10,6 +10,14 @@ on:
         description: "Release tag (e.g. v1.0.2)"
         required: true
 
+concurrency:
+  # A re-pushed or re-dispatched tag fires this a second time. Queue the
+  # duplicate behind the original instead of cancelling it: cancelling a run
+  # mid-publish can leave a channel half-uploaded, whereas a queued duplicate
+  # just hits the "already published" check and exits clean.
+  group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -56,12 +64,29 @@ jobs:
             print(next(p['version'] for p in pkgs if p['name']=='sigit'))")
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-          if curl -fsS "https://crates.io/api/v1/crates/sigit/${VERSION}" >/dev/null 2>&1; then
-            echo "sigit ${VERSION} already exists on crates.io, skipping publish"
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+          # crates.io answers 403 to requests without a descriptive
+          # User-Agent, so curl's default one makes this look like a 404 and
+          # the publish below runs into "crate already exists on the index".
+          # Branch on the status code rather than on curl's exit status, so an
+          # answer we do not understand stops the job instead of quietly
+          # degrading into that same failure.
+          STATUS=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "User-Agent: getsigit/sigit release workflow (github.com/getsigit/sigit)" \
+            "https://crates.io/api/v1/crates/sigit/${VERSION}")
+
+          case "$STATUS" in
+            200)
+              echo "sigit ${VERSION} already exists on crates.io, skipping publish"
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unexpected ${STATUS} from crates.io while checking whether sigit ${VERSION} is published" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Publish to crates.io
         if: steps.crates-check.outputs.exists != 'true'

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -70,8 +70,11 @@ jobs:
           # Branch on the status code rather than on curl's exit status, so an
           # answer we do not understand stops the job instead of quietly
           # degrading into that same failure.
+          # Retry first, so a timeout or a 5xx costs a few seconds instead of
+          # the whole release.
           STATUS=$(curl -sS -o /dev/null -w '%{http_code}' \
-            -H "User-Agent: getsigit/sigit release workflow (github.com/getsigit/sigit)" \
+            --retry 3 --retry-delay 2 --retry-all-errors \
+            -H "User-Agent: ${GITHUB_REPOSITORY} release workflow (https://github.com/${GITHUB_REPOSITORY})" \
             "https://crates.io/api/v1/crates/sigit/${VERSION}")
 
           case "$STATUS" in

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -10,6 +10,14 @@ on:
         description: "Release tag (e.g. v0.1.1)"
         required: true
 
+concurrency:
+  # A re-pushed or re-dispatched tag fires this a second time. Queue the
+  # duplicate behind the original instead of cancelling it: cancelling a run
+  # mid-publish can leave a channel half-uploaded, whereas a queued duplicate
+  # just hits the "already published" check and exits clean.
+  group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   actions: write

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -7,6 +7,14 @@ on:
         description: "Release tag (e.g. v0.1.1)"
         required: true
 
+concurrency:
+  # A re-pushed or re-dispatched tag fires this a second time. Queue the
+  # duplicate behind the original instead of cancelling it: cancelling a run
+  # mid-publish can leave a channel half-uploaded, whereas a queued duplicate
+  # just hits the "already published" check and exits clean.
+  group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -166,9 +166,18 @@ jobs:
           cd "${node_pkg}"
 
           npm_package_name="@getsigit/${node_pkg}"
-          if npm view "${npm_package_name}@${node_version}" version >/dev/null 2>&1; then
+
+          # `npm view` exits non-zero both when the version is genuinely
+          # unpublished and when the registry could not be reached, so treat
+          # only an E404 as "not published yet". Anything else stops the job
+          # instead of publishing over a version that is already there.
+          if view_output=$(npm view "${npm_package_name}@${node_version}" version 2>&1); then
             echo "${npm_package_name}@${node_version} already exists on npm, skipping publish"
             exit 0
+          elif ! grep -q "E404" <<<"${view_output}"; then
+            echo "npm view failed while checking ${npm_package_name}@${node_version}:" >&2
+            echo "${view_output}" >&2
+            exit 1
           fi
 
           npm publish --access public
@@ -222,9 +231,15 @@ jobs:
           npm_package_name="@getsigit/sigit"
           npm_package_version="${{ env.RELEASE_VERSION }}"
 
-          if npm view "${npm_package_name}@${npm_package_version}" version >/dev/null 2>&1; then
+          # Same E404-only reading as the platform packages above: a registry
+          # failure must not look like an unpublished version.
+          if view_output=$(npm view "${npm_package_name}@${npm_package_version}" version 2>&1); then
             echo "${npm_package_name}@${npm_package_version} already exists on npm, skipping publish"
             exit 0
+          elif ! grep -q "E404" <<<"${view_output}"; then
+            echo "npm view failed while checking ${npm_package_name}@${npm_package_version}:" >&2
+            echo "${view_output}" >&2
+            exit 1
           fi
 
           npm install

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -10,6 +10,14 @@ on:
         description: "Release tag (e.g. v0.1.1)"
         required: true
 
+concurrency:
+  # A re-pushed or re-dispatched tag fires this a second time. Queue the
+  # duplicate behind the original instead of cancelling it: cancelling a run
+  # mid-publish can leave a channel half-uploaded, whereas a queued duplicate
+  # just hits the "already published" check and exits clean.
+  group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -304,7 +304,8 @@ jobs:
           # means the package itself is not on NuGet, which is the first
           # release and a real "not published".
           index=$(mktemp)
-          STATUS=$(curl -sS -o "${index}" -w '%{http_code}' "${package_index_url}")
+          STATUS=$(curl -sS -o "${index}" -w '%{http_code}' \
+            --retry 3 --retry-delay 2 --retry-all-errors "${package_index_url}")
 
           case "$STATUS" in
             200)

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -296,12 +296,34 @@ jobs:
         shell: bash
         run: |
           package_index_url="https://api.nuget.org/v3-flatcontainer/sigit.code/index.json"
-          if curl -fsS "${package_index_url}" | grep -F "\"${RELEASE_VERSION}\"" >/dev/null; then
-            echo "${NUGET_PACKAGE_ID} ${RELEASE_VERSION} already exists on NuGet, skipping publish"
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+
+          # Keep the fetch and the version match separate. Piping curl into
+          # grep hides a failed fetch behind an empty match, so an outage or a
+          # blocked request would read as "not published yet" and send the
+          # publish below into a version that is already there. A 404 here
+          # means the package itself is not on NuGet, which is the first
+          # release and a real "not published".
+          index=$(mktemp)
+          STATUS=$(curl -sS -o "${index}" -w '%{http_code}' "${package_index_url}")
+
+          case "$STATUS" in
+            200)
+              if grep -F "\"${RELEASE_VERSION}\"" "${index}" >/dev/null; then
+                echo "${NUGET_PACKAGE_ID} ${RELEASE_VERSION} already exists on NuGet, skipping publish"
+                echo "exists=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "exists=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            404)
+              echo "${NUGET_PACKAGE_ID} is not on NuGet yet, publishing its first version"
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unexpected ${STATUS} from NuGet while checking whether ${NUGET_PACKAGE_ID} ${RELEASE_VERSION} is published" >&2
+              exit 1
+              ;;
+          esac
 
       # Exchange the workflow's OIDC token for a short-lived NuGet API key. The
       # key is written to the environment for the subsequent `dotnet nuget push`

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -10,6 +10,14 @@ on:
         description: "Release tag (e.g. v1.5.2)"
         required: true
 
+concurrency:
+  # A re-pushed or re-dispatched tag fires this a second time. Queue the
+  # duplicate behind the original instead of cancelling it: cancelling a run
+  # mid-publish can leave a channel half-uploaded, whereas a queued duplicate
+  # just hits the "already published" check and exits clean.
+  group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -186,6 +186,7 @@ jobs:
           # blocked request would read as "not published yet" and send the
           # publish below into a version that is already there.
           STATUS=$(curl -sS -o /dev/null -w '%{http_code}' \
+            --retry 3 --retry-delay 2 --retry-all-errors \
             "https://pypi.org/pypi/sigit-code/${RELEASE_VERSION}/json")
 
           case "$STATUS" in

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -181,12 +181,26 @@ jobs:
         id: pypi-check
         shell: bash
         run: |
-          if curl -fsS "https://pypi.org/pypi/sigit-code/${RELEASE_VERSION}/json" >/dev/null 2>&1; then
-            echo "sigit-code ${RELEASE_VERSION} already exists on PyPI, skipping publish"
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+          # Branch on the status code rather than on curl's exit status: with
+          # -f every non-2xx answer looks alike, so a registry outage or a
+          # blocked request would read as "not published yet" and send the
+          # publish below into a version that is already there.
+          STATUS=$(curl -sS -o /dev/null -w '%{http_code}' \
+            "https://pypi.org/pypi/sigit-code/${RELEASE_VERSION}/json")
+
+          case "$STATUS" in
+            200)
+              echo "sigit-code ${RELEASE_VERSION} already exists on PyPI, skipping publish"
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unexpected ${STATUS} from PyPI while checking whether sigit-code ${RELEASE_VERSION} is published" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Publish distribution
         if: steps.pypi-check.outputs.exists != 'true'

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -10,6 +10,14 @@ on:
         description: "Release tag (e.g. v0.1.1)"
         required: true
 
+concurrency:
+  # A re-pushed or re-dispatched tag fires this a second time. Queue the
+  # duplicate behind the original instead of cancelling it: cancelling a run
+  # mid-publish can leave a channel half-uploaded, whereas a queued duplicate
+  # just hits the "already published" check and exits clean.
+  group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/release-scoop.yml
+++ b/.github/workflows/release-scoop.yml
@@ -8,6 +8,14 @@ on:
         description: "Release tag (e.g. v1.5.2)"
         required: true
 
+concurrency:
+  # A re-pushed or re-dispatched tag fires this a second time. Queue the
+  # duplicate behind the original instead of cancelling it: cancelling a run
+  # mid-publish can leave a channel half-uploaded, whereas a queued duplicate
+  # just hits the "already published" check and exits clean.
+  group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -20,6 +20,14 @@ on:
         description: "Release tag (e.g. v1.5.2)"
         required: true
 
+concurrency:
+  # A re-pushed or re-dispatched tag fires this a second time. Queue the
+  # duplicate behind the original instead of cancelling it: cancelling a run
+  # mid-publish can leave a channel half-uploaded, whereas a queued duplicate
+  # just hits the "already published" check and exits clean.
+  group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 


### PR DESCRIPTION
The v1.5.6 tag got pushed twice, 32 seconds apart, so every release workflow fired twice. Four of the duplicate runs were cancelled and the crates.io one failed:

```
error: crate sigit@1.5.6 already exists on crates.io index
```

`release-crates.yml` already had a check for this. It was broken. It asked `https://crates.io/api/v1/crates/sigit/$VERSION` with curl's default User-Agent, and crates.io answers those with a 403. Because the check used `curl -fsS`, the 403 looked the same as a 404, so it decided the version was unpublished and let `cargo publish` run into a version that was already on the index.

### Concurrency

All nine release workflows get a `concurrency` group keyed on the tag, taken from the dispatch input or the ref name so push and dispatch runs land in the same group. `cancel-in-progress` is false, because interrupting a publish that is partway through uploading is worse than the duplicate waiting its turn and then no-opping against the already-published checks.

That only works if those checks are trustworthy, which brings us to the second half.

### The publish checks

crates.io was the one that broke, but npm, PyPI and NuGet were all written the same way: any unhappy answer from the registry read as "not published yet". Only crates.io gates on User-Agent, so the others work today, but an outage or a blocked request would walk each of them into the same publish error.

- crates.io, PyPI and NuGet now branch on the HTTP status. 200 skips the publish, 404 runs it, anything else fails the job. crates.io also sends a User-Agent that identifies the repo.
- NuGet's fetch and version match are split apart, since piping curl into grep hid a failed fetch behind an empty match. A 404 on its index means the package has no versions at all, which is a genuine first release rather than an error.
- npm has no status code to read, so both publish steps still use `npm view` but only accept an `E404` as proof the version is missing.

Checked against the live registries: 1.5.6 reports published on all four, 99.99.99 reports missing, and npm returns `E404` both for an unknown version and an unknown package.

The AGENTS.md release section picks up a short note on why the concurrency group and the publish checks depend on each other.

No Rust changed, so the code half of the CI gate is whatever `development` already had. `cargo fmt -- --check` is clean and every workflow file still parses as YAML.

For the record, v1.5.6 itself is fine: crates.io, npm, PyPI, NuGet, the Homebrew tap and the Scoop bucket all serve 1.5.6, and the winget manifest is now filed as microsoft/winget-pkgs#429467 after the expired `WINGET_TOKEN` was replaced.