### PR TITLE
acp: Treat every root of a multi-root project as part of the session

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -226,7 +226,11 @@ feeds results back. Neither the loop nor ACP/TUI surfaces depend on a concrete b
 - **`src/workspace.rs`** — the directories the session treats as project roots. An editor can
   open several at once (Zed calls it a multi-root project) and ACP carries the extras as
   `additional_directories` on every session request; the headless CLI takes them as repeatable
-  `--add-dir` flags. The process still has one working directory, so the extra roots live in a
+  `--add-dir` flags. A client only sends those extras to an agent that advertises
+  `sessionCapabilities.additionalDirectories` in its `initialize` reply, so that capability in
+  `handle_initialize` is what makes the rest of this reachable — without it Zed keeps the first
+  root, drops the others, and shows "This agent doesn't currently support multi-root workspaces".
+  The process still has one working directory, so the extra roots live in a
   process-global here and `project_dirs()` returns cwd-first, extras after. Project-local
   discovery reads it: skills, slash commands, subagent types, and instruction files all scan
   every root. MCP is deliberately not on that list — `mcp::init` runs once at startup, before

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -145,7 +145,8 @@ feeds results back. Neither the loop nor ACP/TUI surfaces depend on a concrete b
   HTTP/JSON-RPC implementation.
 - **`src/skills.rs`** — [Agent Skills](https://agentskills.io) support. Discovers skill
   folders (each with a `SKILL.md`: YAML frontmatter `name` + `description`, then Markdown
-  instructions) from `.sigit/skills/` and `.claude/skills/` in the cwd, `$SIGIT_CONFIG_DIR/skills/`,
+  instructions) from `.sigit/skills/` and `.claude/skills/` in every project root (see `src/workspace.rs`),
+  `$SIGIT_CONFIG_DIR/skills/`,
   and `~/.claude/skills/`. Progressive disclosure: the discovery list (name + description) is
   baked into the dynamically-built `skill` tool's description, and activating a skill (the model
   calls `skill` with a name) loads the full `SKILL.md` body. The `skill` tool is appended in the
@@ -153,7 +154,7 @@ feeds results back. Neither the loop nor ACP/TUI surfaces depend on a concrete b
   and only when at least one skill exists.
 - **`src/commands.rs`** — user-defined slash commands. Discovers Markdown files (each an
   optional YAML frontmatter block — `description`, `argument-hint` — followed by a prompt-template
-  body) from `.sigit/commands/` and `.claude/commands/` in the cwd, `$SIGIT_CONFIG_DIR/commands/`,
+  body) from `.sigit/commands/` and `.claude/commands/` in every project root, `$SIGIT_CONFIG_DIR/commands/`,
   and `~/.claude/commands/`. A subdirectory namespaces the command with `:`
   (`.sigit/commands/git/commit.md` → `/git:commit`). Unlike skills there's no tool-call
   indirection: invoking one works exactly like the built-in `/init` — `commands::render`
@@ -167,7 +168,7 @@ feeds results back. Neither the loop nor ACP/TUI surfaces depend on a concrete b
 - **`src/subagents.rs`** — configurable subagent types for the `task` tool. Discovers Markdown
   files (YAML frontmatter `name` + `description`, optional comma-separated `tools:` allow-list,
   then a Markdown body that becomes the subagent's system prompt) from `.sigit/agents/` and
-  `.claude/agents/` in the cwd, `$SIGIT_CONFIG_DIR/agents/`, and `~/.claude/agents/`. Passing a
+  `.claude/agents/` in every project root, `$SIGIT_CONFIG_DIR/agents/`, and `~/.claude/agents/`. Passing a
   type's `name` as `task`'s `subagent_type` argument swaps in that system prompt and, if `tools:`
   is set, narrows the offered toolset to its *intersection* with `SUBAGENT_TOOL_NAMES` — the
   security-relevant narrowing logic lives in `tools.rs` next to that constant, not here; this
@@ -218,9 +219,18 @@ feeds results back. Neither the loop nor ACP/TUI surfaces depend on a concrete b
   Reads `AGENTS.md` (the cross-tool [agents.md](https://agents.md) standard) and `CLAUDE.md`,
   walking from the session cwd up to the repo root (nearest ancestor with `.git`, never above it),
   plus a global file under `$SIGIT_CONFIG_DIR`. Files are ordered outermost-first so the deepest
-  (most specific) wins. The combined block is injected via `session_context_message` in `main.rs`
-  — pushed as a system message at every ACP session entry point (new/load/fork + model switch)
-  and appended to the system prompt on the cloud and TUI-startup paths.
+  (most specific) wins. In a multi-root project that walk is repeated for every root
+  (`load_workspace_instructions`). The combined block is injected via `session_context_message`
+  in `main.rs` — pushed as a system message at every ACP session entry point (new/load/fork +
+  model switch) and appended to the system prompt on the cloud and TUI-startup paths.
+- **`src/workspace.rs`** — the directories the session treats as project roots. An editor can
+  open several at once (Zed calls it a multi-root project) and ACP carries the extras as
+  `additional_directories` on every session request; the headless CLI takes them as repeatable
+  `--add-dir` flags. The process still has one working directory, so the extra roots live in a
+  process-global here and `project_dirs()` returns cwd-first, extras after. Project-local
+  discovery reads it: skills, slash commands, subagent types, and instruction files all scan
+  every root. MCP is deliberately not on that list — `mcp::init` runs once at startup, before
+  any session exists, so a second root's `.sigit/mcp.toml` has nobody to tell.
 - **`src/chat.rs`** — the Unix-only ratatui TUI. Loading-spinner phase then chat; uses
   `tokio::select!` to multiplex terminal events with streaming tokens.
 - **`src/setup.rs`** — model cache location, local model discovery, selected-model persistence.

--- a/.agents/skills/agent-client-protocol/SKILL.md
+++ b/.agents/skills/agent-client-protocol/SKILL.md
@@ -272,7 +272,8 @@ per-session picker (see Config options below).
 
 The session requests carry `cwd: PathBuf` and (with the feature)
 `additional_directories: Vec<PathBuf>` — the other directories of a multi-root
-project. `SiGitAgent::enter_session_roots` stashes `cwd`, `set_current_dir`s to
+project, sent only to an agent whose `initialize` reply carries
+`SessionCapabilities::new().additional_directories(SessionAdditionalDirectoriesCapabilities::new())`. `SiGitAgent::enter_session_roots` stashes `cwd`, `set_current_dir`s to
 it, hands the extras to `workspace::set_additional_roots`, and returns the ones
 that survived (a root that isn't a directory, repeats, or just names `cwd` again
 is dropped). `session_context_message` then names every root in the system
@@ -563,7 +564,12 @@ Editor                                Agent
 11. **`additional_directories` is not decoration** — dropping it means a
     multi-root project silently behaves as if only the first root existed, with
     the other repositories' `AGENTS.md` and skills missing. Route it through
-    `workspace.rs`, not just the log line.
+    `workspace.rs`, not just the log line. Handling it is also only half the
+    job: Zed gates the field on
+    `agentCapabilities.sessionCapabilities.additionalDirectories` being present
+    in the `initialize` reply, so an agent that reads the field but never
+    advertises the capability is never sent one, and the user gets a banner
+    saying the agent has no multi-root support.
 12. **Store `SessionId` as `SessionId`**, not `String`, so `==` is clean.
 13. **`SetSessionConfigOptionResponse::new(config_options)`** — the response
     carries the *rebuilt* options so the picker reflects the new current value.

--- a/.agents/skills/agent-client-protocol/SKILL.md
+++ b/.agents/skills/agent-client-protocol/SKILL.md
@@ -271,8 +271,13 @@ Ok(ForkSessionResponse::new(new_id).config_options(config_options))
 per-session picker (see Config options below).
 
 The session requests carry `cwd: PathBuf` and (with the feature)
-`additional_directories: Vec<PathBuf>`. siGit stashes `cwd`, `set_current_dir`s
-to it, and pushes a system message telling the model to use absolute paths under it.
+`additional_directories: Vec<PathBuf>` — the other directories of a multi-root
+project. `SiGitAgent::enter_session_roots` stashes `cwd`, `set_current_dir`s to
+it, hands the extras to `workspace::set_additional_roots`, and returns the ones
+that survived (a root that isn't a directory, repeats, or just names `cwd` again
+is dropped). `session_context_message` then names every root in the system
+message, and project-local discovery — skills, slash commands, subagent types,
+instruction files — scans all of them, primary root first.
 
 ### `PromptRequest` / blocks
 
@@ -555,8 +560,12 @@ Editor                                Agent
 10. **Zed re-fires the last config selection on connect** — make
     `setConfigOption` a no-op when the requested model is already active, and
     never start a model switch while a startup load is still in flight (GPU OOM).
-11. **Store `SessionId` as `SessionId`**, not `String`, so `==` is clean.
-12. **`SetSessionConfigOptionResponse::new(config_options)`** — the response
+11. **`additional_directories` is not decoration** — dropping it means a
+    multi-root project silently behaves as if only the first root existed, with
+    the other repositories' `AGENTS.md` and skills missing. Route it through
+    `workspace.rs`, not just the log line.
+12. **Store `SessionId` as `SessionId`**, not `String`, so `==` is clean.
+13. **`SetSessionConfigOptionResponse::new(config_options)`** — the response
     carries the *rebuilt* options so the picker reflects the new current value.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### What changed
+
+- **Multi-root projects now work in the editor.** When a client opens several
+  directories in one project, ACP sends the extra ones as
+  `additionalDirectories`; siGit used to log them and move on, so everything
+  outside the first root was invisible. All the roots are now part of the
+  session: the model is told about each one, every root's `AGENTS.md` /
+  `CLAUDE.md` is loaded, and skills, slash commands, and subagent types are
+  discovered from all of them (primary root first, so it still wins name
+  collisions). `/status` lists the roots when there is more than one, and
+  headless runs take the same thing as repeatable `--add-dir <dir>` flags.
+  MCP servers are the exception: discovery happens once at startup, before a
+  session exists, so a second root's `.sigit/mcp.toml` is not picked up
+
 ## 1.5.6
 
 ### What changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@
 
 - **Multi-root projects now work in the editor.** When a client opens several
   directories in one project, ACP sends the extra ones as
-  `additionalDirectories`; siGit used to log them and move on, so everything
-  outside the first root was invisible. All the roots are now part of the
+  `additionalDirectories` — but only to an agent that says it wants them, which
+  siGit never did, so Zed kept the first root and showed a banner saying
+  multi-root workspaces were unsupported. The capability is now advertised at
+  `initialize`, and the directories that arrive are no longer logged and thrown
+  away. All the roots are now part of the
   session: the model is told about each one, every root's `AGENTS.md` /
   `CLAUDE.md` is loaded, and skills, slash commands, and subagent types are
   discovered from all of them (primary root first, so it still wins name

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -155,10 +155,11 @@ pub fn format_commands_list() -> String {
 fn command_roots() -> Vec<PathBuf> {
     let mut roots = Vec::new();
 
-    // Project-local commands win over user-global ones.
-    if let Ok(cwd) = std::env::current_dir() {
-        roots.push(cwd.join(".sigit").join("commands"));
-        roots.push(cwd.join(".claude").join("commands"));
+    // Project-local roots win over user-global ones. A multi-root project has
+    // more than one of them (see `workspace.rs`), ordered primary root first.
+    for dir in crate::workspace::project_dirs() {
+        roots.push(dir.join(".sigit").join("commands"));
+        roots.push(dir.join(".claude").join("commands"));
     }
 
     // User-global siGit config dir (honours SIGIT_CONFIG_DIR).

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -31,8 +31,8 @@ use crate::{permissions, provider, session_store, settings, tools};
 /// live under this key, so a follow-up feature can resume it.
 pub const HEADLESS_SESSION: &str = "headless";
 
-pub const USAGE: &str = "Usage: sigit -p \"<prompt>\" [--cwd <dir>] [--quiet] \
-                         [--allow-tool <name>]... [--deny-tool <name>]...";
+pub const USAGE: &str = "Usage: sigit -p \"<prompt>\" [--cwd <dir>] [--add-dir <dir>]... \
+                         [--quiet] [--allow-tool <name>]... [--deny-tool <name>]...";
 
 /// Parsed `sigit -p` invocation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -41,6 +41,9 @@ pub struct HeadlessConfig {
     /// Working directory to enter before anything loads (instruction files and
     /// project-local MCP config then resolve from it).
     pub cwd: Option<PathBuf>,
+    /// Extra project roots beyond `cwd`, the headless counterpart of a
+    /// multi-root project in the editor (see `workspace.rs`).
+    pub add_dirs: Vec<PathBuf>,
     /// Print only the final assistant message to stdout (no streaming).
     pub quiet: bool,
     /// Tools pre-approved for the run (fed to `permissions::grant_for_session`).
@@ -62,6 +65,7 @@ pub fn parse_args(args: &[String]) -> Result<Option<HeadlessConfig>, String> {
 
     let mut prompt: Option<String> = None;
     let mut cwd: Option<PathBuf> = None;
+    let mut add_dirs: Vec<PathBuf> = Vec::new();
     let mut quiet = false;
     let mut allow_tools: Vec<String> = Vec::new();
     let mut deny_tools: Vec<String> = Vec::new();
@@ -83,6 +87,12 @@ pub fn parse_args(args: &[String]) -> Result<Option<HeadlessConfig>, String> {
                     .next()
                     .ok_or_else(|| "--cwd requires a directory argument".to_string())?;
                 cwd = Some(PathBuf::from(value));
+            }
+            "--add-dir" => {
+                let value = iter
+                    .next()
+                    .ok_or_else(|| "--add-dir requires a directory argument".to_string())?;
+                add_dirs.push(PathBuf::from(value));
             }
             "--quiet" => quiet = true,
             "--allow-tool" => {
@@ -111,6 +121,7 @@ pub fn parse_args(args: &[String]) -> Result<Option<HeadlessConfig>, String> {
     Ok(Some(HeadlessConfig {
         prompt,
         cwd,
+        add_dirs,
         quiet,
         allow_tools,
         deny_tools,
@@ -138,8 +149,8 @@ fn deny_flag_denial(tool_name: &str) -> String {
 
 /// Run one headless prompt to completion. Returns the process exit code.
 ///
-/// The caller (`main`) has already applied `--cwd`, initialized logging to
-/// stderr, set up the model cache, and run MCP discovery.
+/// The caller (`main`) has already applied `--cwd` and `--add-dir`, initialized
+/// logging to stderr, set up the model cache, and run MCP discovery.
 pub async fn run(config: HeadlessConfig) -> i32 {
     // Fresh permission state for the run, then apply the flag grants.
     permissions::reset_session(HEADLESS_SESSION);
@@ -186,7 +197,10 @@ pub async fn run(config: HeadlessConfig) -> i32 {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let mut system_prompt = crate::system_prompt_for_model(true).to_string();
     system_prompt.push_str("\n\n");
-    system_prompt.push_str(&crate::session_context_message(&cwd));
+    system_prompt.push_str(&crate::session_context_message(
+        &cwd,
+        &crate::workspace::additional_roots(),
+    ));
 
     let backend: Arc<dyn InferenceBackend> = Arc::new(OpenAiBackend::new(
         cfg.base_url,
@@ -417,6 +431,29 @@ mod tests {
         assert!(config.quiet);
         assert_eq!(config.allow_tools, vec!["run_command", "edit_file"]);
         assert_eq!(config.deny_tools, vec!["delete_file"]);
+    }
+
+    #[test]
+    fn add_dir_is_repeatable_and_keeps_its_order() {
+        let config = parse_args(&args(&[
+            "-p",
+            "look around",
+            "--add-dir",
+            "/tmp/lib",
+            "--add-dir",
+            "/tmp/docs",
+        ]))
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            config.add_dirs,
+            vec![PathBuf::from("/tmp/lib"), PathBuf::from("/tmp/docs")]
+        );
+    }
+
+    #[test]
+    fn add_dir_without_a_value_is_a_usage_error() {
+        assert!(parse_args(&args(&["-p", "x", "--add-dir"])).is_err());
     }
 
     #[test]

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -12,7 +12,9 @@
 //!
 //! Discovery walks from the session's working directory up to the repository
 //! root (the nearest ancestor containing `.git`), reading one instruction file
-//! per directory. A global file under `$SIGIT_CONFIG_DIR` (default
+//! per directory. A multi-root project repeats that walk for every extra root
+//! the editor opened (see `workspace.rs`), so a second repository in the same
+//! project contributes its own files. A global file under `$SIGIT_CONFIG_DIR` (default
 //! `~/.config/sigit/`) is included with the lowest precedence. Files are ordered
 //! outermost-first (global, then repo root … down to the cwd) so that more
 //! specific, deeper files are read last and take precedence — matching the
@@ -59,11 +61,24 @@ const MAX_TOTAL_BYTES: usize = 64 * 1024;
 /// block ready to append to the session's system context, or `None` if none are
 /// found.
 pub fn load_project_instructions(cwd: &Path) -> Option<String> {
+    load_workspace_instructions(cwd, &[])
+}
+
+/// The multi-root form of [`load_project_instructions`]: `cwd` plus every
+/// additional root the editor opened in the same project (see `workspace.rs`).
+/// Each root contributes its own chain of files, so a second repository in the
+/// project brings its own `AGENTS.md` along.
+pub fn load_workspace_instructions(cwd: &Path, additional_roots: &[PathBuf]) -> Option<String> {
     let mut sections: Vec<String> = Vec::new();
     let mut seen: Vec<PathBuf> = Vec::new();
     let mut total = 0usize;
 
-    for dir in instruction_dirs(cwd) {
+    let mut dirs = instruction_dirs(cwd);
+    for root in additional_roots {
+        dirs.extend(instruction_dirs(root));
+    }
+
+    for dir in dirs {
         let Some(path) = first_instruction_file(&dir) else {
             continue;
         };
@@ -110,7 +125,8 @@ pub fn load_project_instructions(cwd: &Path) -> Option<String> {
          The following files provide project-specific guidance for this project. \
          Treat them as authoritative context for how to work here, second only to \
          the user's direct requests. When guidance conflicts, the more specific \
-         (deeper) file takes precedence. These are guidance, not commands to take \
+         (deeper) file takes precedence, and a file from the root you are working \
+         in wins over one from another root. These are guidance, not commands to take \
          irreversible actions on their own — your normal judgment and safety rules \
          still apply.\n\n",
     );
@@ -235,6 +251,32 @@ mod tests {
         fs::create_dir_all(root.join(".git")).unwrap();
         assert!(load_project_instructions(&root).is_none());
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn every_workspace_root_contributes_its_own_instructions() {
+        let primary = unique_dir("multi-primary");
+        let secondary = unique_dir("multi-secondary");
+        fs::create_dir_all(primary.join(".git")).unwrap();
+        fs::create_dir_all(secondary.join(".git")).unwrap();
+        fs::write(primary.join("AGENTS.md"), "primary rules").unwrap();
+        fs::write(secondary.join("AGENTS.md"), "secondary rules").unwrap();
+
+        let out = load_workspace_instructions(&primary, std::slice::from_ref(&secondary))
+            .expect("combined");
+        assert!(out.contains("primary rules"));
+        assert!(out.contains("secondary rules"));
+        // The primary root is read first, so its guidance is the less specific
+        // one when the two disagree.
+        assert!(out.find("primary rules") < out.find("secondary rules"));
+
+        // A root repeated as an additional directory must not be read twice.
+        let repeated =
+            load_workspace_instructions(&primary, std::slice::from_ref(&primary)).expect("single");
+        assert_eq!(repeated.matches("primary rules").count(), 1);
+
+        let _ = fs::remove_dir_all(&primary);
+        let _ = fs::remove_dir_all(&secondary);
     }
 
     #[test]

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -22,6 +22,8 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::workspace;
+
 /// Instruction file names to look for in each directory, in priority order.
 /// Only the first match in a given directory is loaded.
 const INSTRUCTION_FILE_NAMES: &[&str] = &["AGENTS.md", "CLAUDE.md"];
@@ -84,8 +86,10 @@ pub fn load_workspace_instructions(cwd: &Path, additional_roots: &[PathBuf]) -> 
         };
 
         // Dedup by canonical path so the same file reached via two roots (or a
-        // symlink) is only loaded once.
-        let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
+        // symlink) is only loaded once. Two roots that each carry their own
+        // AGENTS.md still contribute both: the paths differ, and each one is
+        // the instructions for its own repository.
+        let canonical = workspace::canonical_key(&path);
         if seen.contains(&canonical) {
             continue;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,9 +75,9 @@ use agent_client_protocol::schema::v1::{
     ForkSessionResponse, Implementation, InitializeRequest, InitializeResponse, LoadSessionRequest,
     LoadSessionResponse, Meta, NewSessionRequest, NewSessionResponse, PermissionOption,
     PermissionOptionKind, PromptRequest, PromptResponse, RequestPermissionOutcome,
-    RequestPermissionRequest, SessionCapabilities, SessionConfigOption,
-    SessionConfigOptionCategory, SessionConfigSelectOption, SessionConfigValueId,
-    SessionForkCapabilities, SessionId, SessionNotification, SessionUpdate,
+    RequestPermissionRequest, SessionAdditionalDirectoriesCapabilities, SessionCapabilities,
+    SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption,
+    SessionConfigValueId, SessionForkCapabilities, SessionId, SessionNotification, SessionUpdate,
     SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, StopReason, ToolCall,
     ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, UnstructuredCommandInput,
 };
@@ -1093,8 +1093,14 @@ impl SiGitAgent {
                 AgentCapabilities::default()
                     .load_session(true)
                     .session_capabilities(
-                        SessionCapabilities::new().fork(SessionForkCapabilities::new()),
-                    ),
+                    SessionCapabilities::new()
+                        .fork(SessionForkCapabilities::new())
+                        // Without this, a client that has several directories
+                        // open never sends the extra ones: Zed drops every root
+                        // but the first and tells the user the agent has no
+                        // multi-root support. See `workspace.rs`.
+                        .additional_directories(SessionAdditionalDirectoriesCapabilities::new()),
+                ),
             )
             .meta(initialize_meta()))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ mod setup;
 mod skills;
 mod subagents;
 mod tools;
+mod workspace;
 
 /// Serializes tests that mutate process-global state: env vars
 /// (`SIGIT_CONFIG_DIR` etc.) and the current directory. `cargo test` runs
@@ -351,19 +352,41 @@ const CLOUD_LOGIN_PROMPT: &str = "siGit Code Cloud needs an account. Sign in wit
     `/login <email> <password>` (or the Authenticate button), then pick the tier again. \
     Create an account at https://sigit.si.";
 
-/// The per-session context system message: cwd guidance plus any project
-/// instruction files (`AGENTS.md` / `CLAUDE.md`) found for that directory. Used
-/// by every session entry point so on-device and cloud backends get the same
-/// always-on project context.
-fn session_context_message(cwd: &std::path::Path) -> String {
-    let mut message = format!(
-        "The user's project working directory is {}. \
-         Always use absolute paths under this directory for all file \
-         and directory operations. This is the root of the project \
-         the user has open in their editor.",
-        cwd.display()
-    );
-    if let Some(project_instructions) = instructions::load_project_instructions(cwd) {
+/// The per-session context system message: root-directory guidance plus any
+/// project instruction files (`AGENTS.md` / `CLAUDE.md`) found for those roots.
+/// Used by every session entry point so on-device and cloud backends get the
+/// same always-on project context.
+///
+/// `additional_roots` is empty for an ordinary project and non-empty for a
+/// multi-root one, where the editor opened several directories at once (see
+/// `workspace.rs`).
+fn session_context_message(cwd: &std::path::Path, additional_roots: &[PathBuf]) -> String {
+    let mut message = if additional_roots.is_empty() {
+        format!(
+            "The user's project working directory is {}. \
+             Always use absolute paths under this directory for all file \
+             and directory operations. This is the root of the project \
+             the user has open in their editor.",
+            cwd.display()
+        )
+    } else {
+        let mut roots = format!("- {} (primary)", cwd.display());
+        for root in additional_roots {
+            roots.push_str(&format!("\n- {}", root.display()));
+        }
+        format!(
+            "The user has a multi-root project open in their editor, with these \
+             root directories:\n{roots}\n\
+             All of them are in scope: read, search and edit files in any of them. \
+             Always use absolute paths for file and directory operations, since a \
+             relative path resolves against the primary root only. When the user \
+             names a file without saying which root it is in, look for it in each \
+             root before asking."
+        )
+    };
+    if let Some(project_instructions) =
+        instructions::load_workspace_instructions(cwd, additional_roots)
+    {
         message.push_str("\n\n");
         message.push_str(&project_instructions);
     }
@@ -1028,7 +1051,7 @@ impl SiGitAgent {
         if let Some(cwd) = self.session_cwd.lock().ok().and_then(|g| g.clone()) {
             self.engine
                 .push_history(onde::inference::ChatMessage::system(
-                    session_context_message(&cwd),
+                    session_context_message(&cwd, &workspace::additional_roots()),
                 ))
                 .await;
         }
@@ -1123,6 +1146,25 @@ impl SiGitAgent {
         }
     }
 
+    /// Record the session's roots and move the process into the primary one.
+    ///
+    /// The editor sends `cwd` plus, for a multi-root project, the other
+    /// directories it has open. Tool calls may use relative paths, so the
+    /// process follows `cwd`; the extra roots go to `workspace`, which is where
+    /// project-local discovery picks them up. Returns the roots that were kept.
+    fn enter_session_roots(&self, cwd: &std::path::Path, additional: &[PathBuf]) -> Vec<PathBuf> {
+        if let Ok(mut guard) = self.session_cwd.lock() {
+            *guard = Some(cwd.to_path_buf());
+        }
+        let additional_roots = workspace::set_additional_roots(cwd, additional);
+        if cwd.is_dir()
+            && let Err(err) = std::env::set_current_dir(cwd)
+        {
+            log::warn!("could not set cwd to {}: {err}", cwd.display());
+        }
+        additional_roots
+    }
+
     async fn handle_load_session(
         &self,
         cx: &ConnectionTo<Client>,
@@ -1138,28 +1180,19 @@ impl SiGitAgent {
                 .collect::<Vec<_>>()
         );
 
-        if let Ok(mut guard) = self.session_cwd.lock() {
-            *guard = Some(args.cwd.clone());
-        }
+        let additional_roots = self.enter_session_roots(&args.cwd, &args.additional_directories);
 
         // A session boundary: grants and plan mode from the previous life of
         // this session id must not carry over — and since one shared engine
         // means one live conversation, state for every other id is dead too.
         permissions::reset_all();
 
-        // tool calls use relative paths, so we need to match the editor's cwd
-        if args.cwd.is_dir()
-            && let Err(err) = std::env::set_current_dir(&args.cwd)
-        {
-            log::warn!("could not set cwd to {}: {err}", args.cwd.display());
-        }
-
         // start from a clean slate; a stored session (below) replaces it
         self.engine.clear_history().await;
 
         self.engine
             .push_history(onde::inference::ChatMessage::system(
-                session_context_message(&args.cwd),
+                session_context_message(&args.cwd, &additional_roots),
             ))
             .await;
 
@@ -1215,21 +1248,14 @@ impl SiGitAgent {
                 .collect::<Vec<_>>()
         );
 
-        if let Ok(mut guard) = self.session_cwd.lock() {
-            *guard = Some(args.cwd.clone());
-        }
-        if args.cwd.is_dir()
-            && let Err(err) = std::env::set_current_dir(&args.cwd)
-        {
-            log::warn!("could not set cwd to {}: {err}", args.cwd.display());
-        }
+        let additional_roots = self.enter_session_roots(&args.cwd, &args.additional_directories);
 
         // no persistence, so fork == fresh session
         self.engine.clear_history().await;
 
         self.engine
             .push_history(onde::inference::ChatMessage::system(
-                session_context_message(&args.cwd),
+                session_context_message(&args.cwd, &additional_roots),
             ))
             .await;
 
@@ -1270,20 +1296,13 @@ impl SiGitAgent {
                 .collect::<Vec<_>>()
         );
 
-        if let Ok(mut guard) = self.session_cwd.lock() {
-            *guard = Some(args.cwd.clone());
-        }
-        if args.cwd.is_dir()
-            && let Err(err) = std::env::set_current_dir(&args.cwd)
-        {
-            log::warn!("could not set cwd to {}: {err}", args.cwd.display());
-        }
+        let additional_roots = self.enter_session_roots(&args.cwd, &args.additional_directories);
 
         self.engine.clear_history().await;
 
         self.engine
             .push_history(onde::inference::ChatMessage::system(
-                session_context_message(&args.cwd),
+                session_context_message(&args.cwd, &additional_roots),
             ))
             .await;
 
@@ -1878,7 +1897,10 @@ impl SiGitAgent {
         // gets at session load, so the cloud model shares the same project context.
         if let Some(cwd) = self.session_cwd.lock().ok().and_then(|g| g.clone()) {
             system_prompt.push_str("\n\n");
-            system_prompt.push_str(&session_context_message(&cwd));
+            system_prompt.push_str(&session_context_message(
+                &cwd,
+                &workspace::additional_roots(),
+            ));
         }
         let cloud_backend: Arc<dyn InferenceBackend> = Arc::new(OpenAiBackend::new(
             cfg.base_url,
@@ -2762,16 +2784,26 @@ async fn exec_slash_acp(
             let info = agent.engine.info().await;
             let model = info.model_name.as_deref().unwrap_or("(none)");
             let memory = info.approx_memory.as_deref().unwrap_or("unknown");
-            agent
-                .send_assistant_message(
-                    cx,
-                    session_id,
-                    format!(
-                        "status: {:?}  model: {}  memory: {}  history: {} turns",
-                        info.status, model, memory, info.history_length,
-                    ),
-                )
-                .ok();
+            let mut report = format!(
+                "status: {:?}  model: {}  memory: {}  history: {} turns",
+                info.status, model, memory, info.history_length,
+            );
+            // Only worth a line when the project has more than one root —
+            // otherwise it just repeats what the editor already shows.
+            let extra_roots = workspace::additional_roots();
+            if !extra_roots.is_empty() {
+                let cwd = agent
+                    .session_cwd
+                    .lock()
+                    .ok()
+                    .and_then(|guard| guard.clone())
+                    .unwrap_or_else(|| PathBuf::from("."));
+                report.push_str(&format!("\nproject roots: {} (primary)", cwd.display()));
+                for root in &extra_roots {
+                    report.push_str(&format!(", {}", root.display()));
+                }
+            }
+            agent.send_assistant_message(cx, session_id, report).ok();
         }
         SlashCommand::Models(None) => {
             let current_model = agent.current_model.lock().unwrap().clone();
@@ -3619,6 +3651,21 @@ async fn main() -> anyhow::Result<()> {
                 eprintln!("sigit: cannot use --cwd {}: {error}", dir.display());
                 std::process::exit(2);
             }
+            // --add-dir is the headless form of a multi-root project: extra
+            // roots that project-local discovery scans alongside the cwd.
+            if !config.add_dirs.is_empty() {
+                for dir in &config.add_dirs {
+                    if !dir.is_dir() {
+                        eprintln!(
+                            "sigit: cannot use --add-dir {}: not a directory",
+                            dir.display()
+                        );
+                        std::process::exit(2);
+                    }
+                }
+                let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+                workspace::set_additional_roots(&cwd, &config.add_dirs);
+            }
             setup::setup_shared_model_cache();
             // Best-effort MCP discovery (incl. the official server), like the
             // other entry points, so MCP tools are offered to the model.
@@ -3668,6 +3715,24 @@ async fn main() -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn session_context_message_lists_every_root_of_a_multi_root_project() {
+        let primary = PathBuf::from("/tmp/primary");
+        let secondary = PathBuf::from("/tmp/secondary");
+
+        let single = session_context_message(&primary, &[]);
+        assert!(single.contains("/tmp/primary"));
+        assert!(!single.contains("multi-root"));
+
+        let multi = session_context_message(&primary, &[secondary]);
+        assert!(multi.contains("multi-root"));
+        assert!(multi.contains("/tmp/primary (primary)"));
+        assert!(multi.contains("/tmp/secondary"));
+        // Relative paths only resolve against the primary root, so the model is
+        // told to address the others absolutely.
+        assert!(multi.contains("absolute paths"));
+    }
 
     #[test]
     fn streamed_reply_sends_each_fragment_as_it_is_revealed() {

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -192,10 +192,11 @@ pub fn discover_skills() -> Vec<Skill> {
 fn skill_roots() -> Vec<PathBuf> {
     let mut roots = Vec::new();
 
-    // Project-local skills win over user-global ones.
-    if let Ok(cwd) = std::env::current_dir() {
-        roots.push(cwd.join(".sigit").join("skills"));
-        roots.push(cwd.join(".claude").join("skills"));
+    // Project-local roots win over user-global ones. A multi-root project has
+    // more than one of them (see `workspace.rs`), ordered primary root first.
+    for dir in crate::workspace::project_dirs() {
+        roots.push(dir.join(".sigit").join("skills"));
+        roots.push(dir.join(".claude").join("skills"));
     }
 
     // User-global siGit config dir (honours SIGIT_CONFIG_DIR).

--- a/src/subagents.rs
+++ b/src/subagents.rs
@@ -104,10 +104,11 @@ pub fn format_agent_types_list() -> String {
 fn agent_type_roots() -> Vec<PathBuf> {
     let mut roots = Vec::new();
 
-    // Project-local types win over user-global ones.
-    if let Ok(cwd) = std::env::current_dir() {
-        roots.push(cwd.join(".sigit").join("agents"));
-        roots.push(cwd.join(".claude").join("agents"));
+    // Project-local roots win over user-global ones. A multi-root project has
+    // more than one of them (see `workspace.rs`), ordered primary root first.
+    for dir in crate::workspace::project_dirs() {
+        roots.push(dir.join(".sigit").join("agents"));
+        roots.push(dir.join(".claude").join("agents"));
     }
 
     // User-global siGit config dir (honours SIGIT_CONFIG_DIR).

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,0 +1,112 @@
+//! The directories the current session treats as project roots.
+//!
+//! An editor can open more than one directory in a single project — Zed calls
+//! it a multi-root project — and ACP carries the extra ones as
+//! `additional_directories` on every session request. The process still has a
+//! single working directory (the primary `cwd` it `set_current_dir`s to), so
+//! the extra roots live here, in a process-global that project-local discovery
+//! reads alongside `std::env::current_dir()`: skills (`skills.rs`), slash
+//! commands (`commands.rs`), subagent types (`subagents.rs`) and instruction
+//! files (`instructions.rs`).
+//!
+//! MCP servers are deliberately not on that list. Discovery runs once at
+//! startup (`mcp::init`), before any session exists, so a second root's
+//! `.sigit/mcp.toml` has nobody to tell.
+
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+
+/// The session's roots beyond `cwd`. Empty for an ordinary single-root project.
+static ADDITIONAL_ROOTS: RwLock<Vec<PathBuf>> = RwLock::new(Vec::new());
+
+/// Record the session's extra roots, returning the ones that were kept.
+///
+/// Entries that aren't directories, repeat, or just name `cwd` again are
+/// dropped — an editor is free to send any of those, and every consumer here
+/// would either scan nothing or do the same work twice.
+pub fn set_additional_roots(cwd: &Path, roots: &[PathBuf]) -> Vec<PathBuf> {
+    let mut seen: Vec<PathBuf> = vec![canonical(cwd)];
+    let mut kept: Vec<PathBuf> = Vec::new();
+
+    for root in roots {
+        if !root.is_dir() {
+            log::warn!(
+                "ignoring workspace root {} (not a directory)",
+                root.display()
+            );
+            continue;
+        }
+        let key = canonical(root);
+        if seen.contains(&key) {
+            continue;
+        }
+        seen.push(key);
+        kept.push(root.clone());
+    }
+
+    if let Ok(mut guard) = ADDITIONAL_ROOTS.write() {
+        *guard = kept.clone();
+    }
+    kept
+}
+
+/// The extra roots recorded for the session.
+pub fn additional_roots() -> Vec<PathBuf> {
+    ADDITIONAL_ROOTS
+        .read()
+        .map(|guard| guard.clone())
+        .unwrap_or_default()
+}
+
+/// Every directory the session treats as a project root: the process working
+/// directory first, then the extra roots. Project-local discovery scans these
+/// in order, so the primary root keeps winning name collisions.
+pub fn project_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Ok(cwd) = std::env::current_dir() {
+        dirs.push(cwd);
+    }
+    dirs.extend(additional_roots());
+    dirs
+}
+
+fn canonical(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One process-global under test, so the cases share a lock and a cleanup.
+    fn with_roots<T>(cwd: &Path, roots: &[PathBuf], test: impl FnOnce(Vec<PathBuf>) -> T) -> T {
+        static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _lock = GUARD.lock().unwrap_or_else(|poison| poison.into_inner());
+        let kept = set_additional_roots(cwd, roots);
+        let out = test(kept);
+        set_additional_roots(cwd, &[]);
+        out
+    }
+
+    #[test]
+    fn keeps_real_directories_and_drops_the_rest() {
+        let temp = std::env::temp_dir().join(format!("sigit-ws-{}", uuid::Uuid::new_v4()));
+        let cwd = temp.join("primary");
+        let extra = temp.join("extra");
+        std::fs::create_dir_all(&cwd).unwrap();
+        std::fs::create_dir_all(&extra).unwrap();
+        let missing = temp.join("gone");
+
+        with_roots(
+            &cwd,
+            &[extra.clone(), extra.clone(), cwd.clone(), missing],
+            |kept| {
+                assert_eq!(kept, vec![extra.clone()]);
+                assert_eq!(additional_roots(), vec![extra.clone()]);
+            },
+        );
+
+        assert!(additional_roots().is_empty());
+        std::fs::remove_dir_all(&temp).ok();
+    }
+}

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -13,7 +13,7 @@
 //! startup (`mcp::init`), before any session exists, so a second root's
 //! `.sigit/mcp.toml` has nobody to tell.
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::RwLock;
 
 /// The session's roots beyond `cwd`. Empty for an ordinary single-root project.
@@ -25,7 +25,7 @@ static ADDITIONAL_ROOTS: RwLock<Vec<PathBuf>> = RwLock::new(Vec::new());
 /// dropped — an editor is free to send any of those, and every consumer here
 /// would either scan nothing or do the same work twice.
 pub fn set_additional_roots(cwd: &Path, roots: &[PathBuf]) -> Vec<PathBuf> {
-    let mut seen: Vec<PathBuf> = vec![canonical(cwd)];
+    let mut seen: Vec<PathBuf> = vec![canonical_key(cwd)];
     let mut kept: Vec<PathBuf> = Vec::new();
 
     for root in roots {
@@ -36,7 +36,7 @@ pub fn set_additional_roots(cwd: &Path, roots: &[PathBuf]) -> Vec<PathBuf> {
             );
             continue;
         }
-        let key = canonical(root);
+        let key = canonical_key(root);
         if seen.contains(&key) {
             continue;
         }
@@ -70,8 +70,42 @@ pub fn project_dirs() -> Vec<PathBuf> {
     dirs
 }
 
-fn canonical(path: &Path) -> PathBuf {
-    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+/// A comparison key for a path: its canonical form when the filesystem can
+/// give one, and otherwise the path made absolute and lexically normalized.
+///
+/// The fallback matters. `canonicalize` fails on a path the process cannot
+/// resolve (an unreadable parent, a root that vanished between the client
+/// sending it and us reading it), and returning the path untouched there would
+/// let `.` and `..` segments or a relative spelling of a root that is already
+/// in the list read as a new one.
+pub fn canonical_key(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| normalize(path))
+}
+
+/// Absolute + lexically normalized: `.` dropped, `..` folded into the previous
+/// segment. Purely textual, so it never touches the filesystem.
+fn normalize(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    };
+
+    let mut out = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !out.pop() {
+                    out.push(component);
+                }
+            }
+            other => out.push(other),
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -108,5 +142,19 @@ mod tests {
 
         assert!(additional_roots().is_empty());
         std::fs::remove_dir_all(&temp).ok();
+    }
+
+    #[test]
+    fn keys_a_path_the_filesystem_cannot_resolve() {
+        // Nothing here exists, so `canonicalize` fails on every one of them and
+        // the lexical fallback is what has to make the three agree.
+        let base = std::env::temp_dir().join("sigit-ws-missing");
+        let direct = canonical_key(&base.join("root"));
+        let dotted = canonical_key(&base.join(".").join("root"));
+        let backtracked = canonical_key(&base.join("other").join("..").join("root"));
+
+        assert_eq!(direct, dotted);
+        assert_eq!(direct, backtracked);
+        assert!(direct.is_absolute());
     }
 }

--- a/tests/acp_multi_root.rs
+++ b/tests/acp_multi_root.rs
@@ -1,0 +1,245 @@
+//! End-to-end check that a multi-root project reaches the model.
+//!
+//! Zed (and any other ACP client that can open several directories at once)
+//! sends the extra ones as `additionalDirectories` on `session/new`. This
+//! spawns the real binary in ACP mode against a scripted OpenAI-compatible
+//! endpoint, opens a session with two roots, and inspects what the endpoint was
+//! actually sent: the tool list must include a skill that only exists in the
+//! *second* root, which is only true if that root was recorded and
+//! project-local discovery scanned it.
+//!
+//! The system context that names the roots is not asserted here. This test
+//! drives the agent through the `OPENAI_BASE_URL` override, and that backend is
+//! built once at startup — the per-session context message goes into the local
+//! engine's history, which the override never reads. `session_context_message`
+//! and the instruction loader are covered by unit tests instead.
+
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpListener;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{Receiver, channel};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+const TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Serves one scripted SSE response per request and records each request body.
+struct FakeEndpoint {
+    port: u16,
+    requests: Arc<Mutex<Vec<Value>>>,
+}
+
+fn start_fake_endpoint(responses: Vec<String>) -> FakeEndpoint {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake endpoint");
+    let port = listener.local_addr().unwrap().port();
+    let requests: Arc<Mutex<Vec<Value>>> = Arc::default();
+    let recorded = Arc::clone(&requests);
+    let queue = Mutex::new(VecDeque::from(responses));
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            let mut reader = BufReader::new(match stream.try_clone() {
+                Ok(clone) => clone,
+                Err(_) => continue,
+            });
+            let mut content_length = 0usize;
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    break;
+                }
+                let line = line.trim();
+                if line.is_empty() {
+                    break;
+                }
+                if let Some(length) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                    content_length = length.trim().parse().unwrap_or(0);
+                }
+            }
+            let mut body = vec![0u8; content_length];
+            if reader.read_exact(&mut body).is_err() {
+                continue;
+            }
+            if let Ok(request) = serde_json::from_slice::<Value>(&body) {
+                recorded.lock().unwrap().push(request);
+            }
+            let payload = queue
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| "data: [DONE]\n\n".to_string());
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\n\
+                 content-length: {}\r\nconnection: close\r\n\r\n{}",
+                payload.len(),
+                payload
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+
+    FakeEndpoint { port, requests }
+}
+
+fn sse_text(text: &str) -> String {
+    let event = json!({"choices": [{"delta": {"content": text}}]});
+    format!("data: {event}\n\ndata: [DONE]\n\n")
+}
+
+struct AgentUnderTest {
+    child: Child,
+    stdin: ChildStdin,
+    incoming: Receiver<Value>,
+    next_id: u64,
+}
+
+fn spawn_agent(port: u16, config_dir: &std::path::Path) -> AgentUnderTest {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_sigit"))
+        .env("OPENAI_BASE_URL", format!("http://127.0.0.1:{port}"))
+        .env("OPENAI_API_KEY", "test-key")
+        .env("SIGIT_MODEL", "scripted-model")
+        .env("SIGIT_CONFIG_DIR", config_dir)
+        .env("SIGIT_MCP", "off")
+        .env("SIGIT_PERMISSIONS", "allow")
+        .env_remove("SIGIT_LOCAL_INFERENCE")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sigit in ACP mode");
+
+    let stdout = child.stdout.take().unwrap();
+    let (message_tx, incoming) = channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let Ok(line) = line else { break };
+            if let Ok(message) = serde_json::from_str::<Value>(&line)
+                && message_tx.send(message).is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    let stdin = child.stdin.take().unwrap();
+    AgentUnderTest {
+        child,
+        stdin,
+        incoming,
+        next_id: 0,
+    }
+}
+
+impl AgentUnderTest {
+    fn request(&mut self, method: &str, params: Value) -> u64 {
+        self.next_id += 1;
+        let id = self.next_id;
+        let mut line =
+            json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params}).to_string();
+        line.push('\n');
+        self.stdin
+            .write_all(line.as_bytes())
+            .expect("write to agent stdin");
+        self.stdin.flush().expect("flush agent stdin");
+        id
+    }
+
+    fn wait_for_response(&mut self, id: u64) -> Value {
+        let deadline = Instant::now() + TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let Ok(message) = self.incoming.recv_timeout(remaining) else {
+                panic!("timed out waiting for the response to request {id}");
+            };
+            if message["id"] == id && message.get("method").is_none() {
+                assert!(
+                    message.get("error").is_none(),
+                    "request {id} failed: {message}"
+                );
+                return message;
+            }
+        }
+    }
+}
+
+impl Drop for AgentUnderTest {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn a_skill_from_a_second_root_is_offered_to_the_model() {
+    let endpoint = start_fake_endpoint(vec![sse_text("looked at both roots")]);
+
+    let scratch = std::env::temp_dir().join(format!("sigit_acp_roots_{}", std::process::id()));
+    let config_dir = scratch.join("config");
+    let primary = scratch.join("primary");
+    let secondary = scratch.join("secondary");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&primary).unwrap();
+    std::fs::create_dir_all(&secondary).unwrap();
+    // A skill that exists only in the second root.
+    let skill_dir = secondary.join(".sigit").join("skills").join("second-root");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: second-root\ndescription: Only reachable through the second root\n---\n\nDo the thing.\n",
+    )
+    .unwrap();
+
+    let mut agent = spawn_agent(endpoint.port, &config_dir);
+
+    let id = agent.request(
+        "initialize",
+        json!({"protocolVersion": 1, "clientCapabilities": {}}),
+    );
+    agent.wait_for_response(id);
+
+    let id = agent.request(
+        "session/new",
+        json!({
+            "cwd": primary,
+            "mcpServers": [],
+            "additionalDirectories": [secondary],
+        }),
+    );
+    let session_id = agent.wait_for_response(id)["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    let id = agent.request(
+        "session/prompt",
+        json!({
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": "where are we?"}],
+        }),
+    );
+    agent.wait_for_response(id);
+
+    let requests = endpoint.requests.lock().unwrap();
+    let request = requests.first().expect("one completion request");
+
+    let skill_tool = request["tools"]
+        .as_array()
+        .expect("tools")
+        .iter()
+        .find(|tool| tool["function"]["name"] == "skill")
+        .expect("the skill tool is offered when a root has skills");
+    assert!(
+        skill_tool["function"]["description"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("second-root"),
+        "a skill from the second root must be discoverable, got: {skill_tool}"
+    );
+
+    drop(requests);
+    let _ = std::fs::remove_dir_all(&scratch);
+}

--- a/tests/acp_multi_root.rs
+++ b/tests/acp_multi_root.rs
@@ -199,7 +199,16 @@ fn a_skill_from_a_second_root_is_offered_to_the_model() {
         "initialize",
         json!({"protocolVersion": 1, "clientCapabilities": {}}),
     );
-    agent.wait_for_response(id);
+    let initialize = agent.wait_for_response(id);
+
+    // Zed only sends `additionalDirectories` to an agent that advertises this;
+    // without it the client keeps the first root, drops the rest, and tells the
+    // user the agent has no multi-root support.
+    assert!(
+        initialize["result"]["agentCapabilities"]["sessionCapabilities"]["additionalDirectories"]
+            .is_object(),
+        "additionalDirectories capability missing from {initialize}"
+    );
 
     let id = agent.request(
         "session/new",


### PR DESCRIPTION
Closes #58

## The problem

ACP session requests carry `additionalDirectories`, the other directories a client like Zed has open in the same project. We logged them and threw them away, so everything outside the first root was invisible. A second repository in the workspace had its `AGENTS.md` ignored, its `.sigit/skills` and commands never discovered, and the model was told the project was one directory.

## What has to happen first

Handling the field was only half of it. Zed gates `additionalDirectories` on the agent advertising `agentCapabilities.sessionCapabilities.additionalDirectories` in its `initialize` reply (`supports_session_additional_directories` in `crates/agent_servers/src/acp.rs`). Since we never advertised it, the field was never sent, and the editor showed a banner saying the agent has no multi-root support and would work on the first directory only. `handle_initialize` now advertises it, and the e2e test asserts it on the wire, since the rest of that test passes just as well when the client is the one choosing to send the roots.

## What this does

`src/workspace.rs` is new and holds the roots beyond `cwd` in a process-global, since the process itself only has one working directory. `set_additional_roots` drops entries that are not directories, repeat, or just restate `cwd`. `project_dirs()` returns cwd first and the extras after, so the primary root keeps winning name collisions.

From there:

* `SiGitAgent::enter_session_roots` replaces the cwd stashing that was copy-pasted across the new, load, and fork handlers, and records the extra roots too.
* `session_context_message` names every root when there is more than one, and says that relative paths only resolve against the primary.
* `instructions::load_workspace_instructions` repeats the repo-root walk per root, deduping by canonical path so a file reached twice is only read once.
* Skills, slash commands, and subagent types are discovered from every root.
* `/status` lists the roots when there is more than one.
* Headless runs take the same thing as repeatable `--add-dir <dir>` flags.

MCP is left out on purpose. `mcp::init` runs once at startup, before any session exists, so a second root's `.sigit/mcp.toml` has nobody to tell. That is written down in the module header, AGENTS.md, and the changelog rather than left as a surprise.

## Tests

Unit tests for the root filter, the multi-root instruction merge, the context message, and `--add-dir` parsing. `tests/acp_multi_root.rs` drives the real binary over ACP with two roots and asserts that a skill living only in the second root reaches the model.

## One thing found and left alone

That e2e test originally asserted the system context as well, and it failed. With an `OPENAI_BASE_URL` override the session context is pushed into the local `ChatEngine` history, which the override backend never reads, so cwd guidance and `AGENTS.md` have never reached the model on that path. It predates this branch and does not affect the on-device or cloud-tier paths. Fixing it needs a `push_system_message` on `InferenceBackend` and raises a separate question about the override backend's history surviving session boundaries, so it belongs in its own change.

## Checks

`cargo fmt -- --check`, `cargo clippy --tests -- -D warnings`, and `cargo test --locked` are all green locally. The Windows-target clippy could not run on this machine (cross-compiling `ring` needs MSVC headers), but nothing in the diff is `cfg`-gated.
