### PR TITLE
Stop a tool command from wedging the ACP session

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -126,7 +126,13 @@ feeds results back. Neither the loop nor ACP/TUI surfaces depend on a concrete b
   spec list (`all_tools`) and the execute `match` (`execute_tool`). `run_command` also enforces
   commit attribution: when a command creates a new commit that lacks the
   `Co-Authored-By: siGit Code` trailer (`COMMIT_CO_AUTHOR_TRAILER`), it amends the trailer in —
-  unless the commit already exists on a remote, which is never rewritten. Also owns the `task`
+  unless the commit already exists on a remote, which is never rewritten. Every child process it
+  spawns (`spawn_shell`, the `git` helpers, and `hooks.rs`) sets `stdin` to null and never
+  inherits it: in ACP mode sigit's stdin is the JSON-RPC pipe from the editor, so a command that
+  reads stdin both blocks forever and eats the client's next request, wedging the session past
+  any timeout. On Unix the shell also leads its own process group so the timeout kills the whole
+  tree, and stdout/stderr are drained on threads while the command runs — waiting first and
+  reading after deadlocks as soon as the output outgrows the pipe buffer. Also owns the `task`
   tool: a nested agent loop in a fresh conversation, offered only when `subagent_available()`
   (a subagent factory is registered — see `register_subagent_factory_for` in `main.rs`; on-device
   registers a `None`-returning factory since onde has a single shared history). A subagent's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **A shell command can no longer wedge the editor session.** Tool commands
+  inherited siGit's own stdin, which in ACP mode is the JSON-RPC pipe from the
+  editor. A command that read stdin — a signing passphrase prompt, a pager, a
+  `git` credential ask — blocked on it and consumed the client's next request
+  out of the pipe, so nothing typed afterwards ever reached the agent and the
+  session stayed dead past the command timeout. Commands, hooks, and the
+  co-author `git` helpers now run with stdin closed, so a command that wants
+  input gets EOF and reports an error instead
+- **A command that prints a lot no longer stalls for two minutes.**
+  `run_command` waited for the command to exit before reading its output, so
+  anything past the pipe buffer (a build, a verbose test run) blocked writing
+  while siGit blocked waiting, until the 120-second timeout killed it. Output
+  is now drained while the command runs
+- **The command timeout now stops the whole command.** It killed only the
+  shell, leaving anything that shell had started running and unreaped; it now
+  kills the process group
+
 ## 1.5.6
 
 ### What changed

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -198,6 +198,9 @@ fn run_hook(cmd: &str, context: &HookContext, cwd: &Path, timeout: Duration) {
         .arg(&substituted)
         .current_dir(cwd)
         .envs(context.env_vars())
+        // Never the agent's stdin: in ACP mode that is the JSON-RPC pipe from
+        // the editor, and a hook reading it swallows the client's next request.
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     // Put the hook in its own process group so a timeout kill can take out the

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1941,22 +1941,57 @@ fn exec_delete_file(arguments: &str) -> String {
 
 const COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 const COMMAND_OUTPUT_LIMIT: usize = 50_000;
+/// How long to keep waiting for the output drains once the command itself has
+/// exited. Only a process that outlived the shell and still holds a pipe can
+/// use this up, so it is short.
+const OUTPUT_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// Spawn `command_str` through the platform shell with piped stdout/stderr.
 /// Shared by the foreground and background paths of `run_command`.
+///
+/// stdin is `/dev/null`, never inherited. In ACP mode sigit's stdin is the
+/// JSON-RPC pipe from the editor, and a child holding that fd can read the
+/// client's next request out of it: the agent never sees the request, the
+/// editor waits forever for a reply, and the session is wedged past any
+/// timeout this function's callers apply. Null also means a command that wants
+/// input gets EOF and fails instead of blocking on input nobody can type.
+///
+/// On Unix the child also leads its own process group, so a timeout can kill
+/// the whole tree. `sh -c` may fork rather than exec (dash does), and a
+/// surviving grandchild keeps the pipe write ends open.
 fn spawn_shell(command_str: &str, cwd_path: &Path) -> std::io::Result<std::process::Child> {
     #[cfg(unix)]
     let (shell, flag) = ("sh", "-c");
     #[cfg(windows)]
     let (shell, flag) = ("cmd", "/C");
 
-    Command::new(shell)
+    let mut command = Command::new(shell);
+    command
         .arg(flag)
         .arg(command_str)
         .current_dir(cwd_path)
+        .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
+        .stderr(std::process::Stdio::piped());
+    #[cfg(unix)]
+    std::os::unix::process::CommandExt::process_group(&mut command, 0);
+    command.spawn()
+}
+
+/// SIGKILL a shell spawned by [`spawn_shell`] and everything it started, then
+/// reap it so the timeout path doesn't leave a zombie behind.
+fn kill_shell_tree(child: &mut std::process::Child) {
+    #[cfg(unix)]
+    {
+        // Negative pid is the process group; the child is its leader. Fall
+        // back to the child alone if the group is already gone.
+        if unsafe { libc::kill(-(child.id() as i32), libc::SIGKILL) } != 0 {
+            let _ = child.kill();
+        }
+    }
+    #[cfg(windows)]
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 /// Trailer identifying siGit Code as the co-author of commits it creates.
@@ -1970,10 +2005,15 @@ fn spawn_shell(command_str: &str, cwd_path: &Path) -> std::io::Result<std::proce
 pub const COMMIT_CO_AUTHOR_TRAILER: &str = "Co-Authored-By: siGit Code <noreply@sigit.si>";
 
 /// Run `git <args>` in `cwd`, returning trimmed stdout on success.
+///
+/// stdin is null for the same reason as [`spawn_shell`]: git can ask for input
+/// (a credential, a signing passphrase), and inheriting the ACP pipe would let
+/// it read the editor's next request instead.
 fn git_stdout(cwd: &Path, args: &[&str]) -> Option<String> {
     let output = Command::new("git")
         .args(args)
         .current_dir(cwd)
+        .stdin(std::process::Stdio::null())
         .output()
         .ok()?;
     output
@@ -2008,6 +2048,7 @@ fn ensure_commit_co_author(cwd: &Path) -> Option<String> {
     let amend = Command::new("git")
         .args(["commit", "--amend", "--no-edit", "--trailer"])
         .arg(COMMIT_CO_AUTHOR_TRAILER)
+        .stdin(std::process::Stdio::null())
         .current_dir(cwd)
         .output()
         .ok()?;
@@ -2086,13 +2127,33 @@ fn exec_run_command(arguments: &str) -> String {
         Err(err) => return format!("Error: failed to spawn command: {err}"),
     };
 
+    // Drain both pipes on their own threads. Waiting first and reading after
+    // deadlocks the moment a command writes more than the pipe buffer holds
+    // (64 KiB on Linux, less on macOS): the child blocks on the full pipe, we
+    // block on the child, and the only way out is the timeout. A build or a
+    // verbose test run crosses that on its own.
+    let (chunks_tx, chunks_rx) = std::sync::mpsc::channel::<(u8, Vec<u8>)>();
+    let drain = |tag: u8, pipe: Option<Box<dyn std::io::Read + Send>>| {
+        let tx = chunks_tx.clone();
+        std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            if let Some(mut pipe) = pipe {
+                let _ = pipe.read_to_end(&mut buf);
+            }
+            let _ = tx.send((tag, buf));
+        });
+    };
+    drain(0, child.stdout.take().map(|pipe| Box::new(pipe) as _));
+    drain(1, child.stderr.take().map(|pipe| Box::new(pipe) as _));
+    drop(chunks_tx);
+
     let start = std::time::Instant::now();
-    loop {
+    let status = loop {
         match child.try_wait() {
-            Ok(Some(_status)) => break,
+            Ok(Some(status)) => break status,
             Ok(None) => {
                 if start.elapsed() >= COMMAND_TIMEOUT {
-                    let _ = child.kill();
+                    kill_shell_tree(&mut child);
                     return format!(
                         "Error: command timed out after {} seconds and was killed.",
                         COMMAND_TIMEOUT.as_secs()
@@ -2102,17 +2163,27 @@ fn exec_run_command(arguments: &str) -> String {
             }
             Err(err) => return format!("Error: failed to wait on command: {err}"),
         }
-    }
-
-    let output = match child.wait_with_output() {
-        Ok(o) => o,
-        Err(err) => return format!("Error: failed to read command output: {err}"),
     };
 
-    let exit_code = output.status.code().unwrap_or(-1);
+    // Collect what the drains read, bounded. The shell has exited, but a
+    // grandchild that outlived it can still hold a pipe open, and joining
+    // those threads would wait on it forever.
+    let mut stdout_bytes = Vec::new();
+    let mut stderr_bytes = Vec::new();
+    let deadline = std::time::Instant::now() + OUTPUT_GRACE;
+    for _ in 0..2 {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        match chunks_rx.recv_timeout(remaining) {
+            Ok((0, bytes)) => stdout_bytes = bytes,
+            Ok((_, bytes)) => stderr_bytes = bytes,
+            Err(_) => break,
+        }
+    }
+
+    let exit_code = status.code().unwrap_or(-1);
     let mut combined = String::new();
-    combined.push_str(&String::from_utf8_lossy(&output.stdout));
-    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    combined.push_str(&String::from_utf8_lossy(&stdout_bytes));
+    combined.push_str(&String::from_utf8_lossy(&stderr_bytes));
 
     // A new commit appeared under this command: make sure it carries the
     // siGit co-author trailer (see `ensure_commit_co_author`).
@@ -2136,7 +2207,7 @@ fn exec_run_command(arguments: &str) -> String {
         combined
     };
 
-    if output.status.success() {
+    if status.success() {
         if truncated.is_empty() {
             format!("Command succeeded (exit code {exit_code}) with no output.")
         } else {
@@ -3083,6 +3154,55 @@ mod tests {
             "git {args:?} failed: {}",
             String::from_utf8_lossy(&out.stderr)
         );
+    }
+
+    /// The wait loop used to read the pipes only after the child exited, so a
+    /// command that outgrew the pipe buffer blocked on the write, we blocked on
+    /// the child, and the whole thing sat there until the 120-second timeout.
+    #[test]
+    fn run_command_survives_more_output_than_a_pipe_buffer_holds() {
+        let dir = std::env::temp_dir();
+        // ~400 KB, well past any platform's pipe buffer. It also crosses
+        // COMMAND_OUTPUT_LIMIT, so the result is truncated; the point of the
+        // test is that the command finishes at all.
+        let line = "x".repeat(199);
+        let command = format!("for i in $(seq 1 2000); do echo {line}; done");
+        let args = json!({"command": command, "cwd": dir.to_str().unwrap()}).to_string();
+
+        let started = std::time::Instant::now();
+        let result = exec_run_command(&args);
+
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(30),
+            "run_command took {:?}; it deadlocked on the pipe",
+            started.elapsed()
+        );
+        assert!(
+            result.contains("Exit code 0"),
+            "unexpected result: {result}"
+        );
+        assert!(
+            result.contains("output truncated"),
+            "expected the 50000-byte cap to bite: {result}"
+        );
+    }
+
+    /// A command that wants input gets EOF instead of blocking forever on a
+    /// pipe nobody is going to write to (in ACP mode, the editor's own).
+    #[test]
+    fn run_command_gives_a_command_that_reads_stdin_an_empty_one() {
+        let dir = std::env::temp_dir();
+        let args = json!({"command": "cat", "cwd": dir.to_str().unwrap()}).to_string();
+
+        let started = std::time::Instant::now();
+        let result = exec_run_command(&args);
+
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(30),
+            "run_command blocked on stdin for {:?}",
+            started.elapsed()
+        );
+        assert!(result.contains("no output"), "unexpected result: {result}");
     }
 
     #[test]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -3166,7 +3166,14 @@ mod tests {
         // COMMAND_OUTPUT_LIMIT, so the result is truncated; the point of the
         // test is that the command finishes at all.
         let line = "x".repeat(199);
+        // ~400 KB, well past any platform's pipe buffer. It also crosses
+        // COMMAND_OUTPUT_LIMIT, so the result is truncated; the point of the
+        // test is that the command finishes at all.
+        #[cfg(unix)]
         let command = format!("for i in $(seq 1 2000); do echo {line}; done");
+        // cmd has no seq; echo is a builtin so 2000 iterations stay fast.
+        #[cfg(windows)]
+        let command = format!("for /L %i in (1,1,2000) do @echo {line}");
         let args = json!({"command": command, "cwd": dir.to_str().unwrap()}).to_string();
 
         let started = std::time::Instant::now();

--- a/tests/acp_tool_stdin.rs
+++ b/tests/acp_tool_stdin.rs
@@ -1,0 +1,235 @@
+//! Regression: a tool's child process must never share the agent's stdin.
+//!
+//! In ACP mode stdin is the JSON-RPC pipe from the editor. `run_command` spawns
+//! through the platform shell, and a child that inherits that pipe can read the
+//! client's next request out of it. The request is then gone: the agent never
+//! sees it, the editor waits for a reply that cannot come, and the session is
+//! wedged for good — the symptom filed as "acp: model hangs".
+
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpListener;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::Mutex;
+use std::sync::mpsc::{Receiver, channel};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+const TIMEOUT: Duration = Duration::from_secs(30);
+
+fn sse_body(chunks: &[Value]) -> String {
+    let mut body = String::new();
+    for chunk in chunks {
+        body.push_str(&format!("data: {chunk}\n\n"));
+    }
+    body.push_str("data: [DONE]\n\n");
+    body
+}
+
+fn sse_tool_call(id: &str, name: &str, arguments: &str) -> String {
+    sse_body(&[json!({
+        "choices": [{"delta": {"tool_calls": [{
+            "index": 0,
+            "id": id,
+            "function": {"name": name, "arguments": arguments},
+        }]}}]
+    })])
+}
+
+fn sse_text(text: &str) -> String {
+    sse_body(&[json!({"choices": [{"delta": {"content": text}}]})])
+}
+
+struct FakeEndpoint {
+    port: u16,
+}
+
+fn start_fake_endpoint(responses: Vec<String>) -> FakeEndpoint {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake endpoint");
+    let port = listener.local_addr().unwrap().port();
+    let queue = Mutex::new(VecDeque::from(responses));
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            let mut reader = BufReader::new(match stream.try_clone() {
+                Ok(clone) => clone,
+                Err(_) => continue,
+            });
+            let mut content_length = 0usize;
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    break;
+                }
+                let line = line.trim();
+                if line.is_empty() {
+                    break;
+                }
+                if let Some(length) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                    content_length = length.trim().parse().unwrap_or(0);
+                }
+            }
+            let mut body = vec![0u8; content_length];
+            if reader.read_exact(&mut body).is_err() {
+                continue;
+            }
+            let payload = queue
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| "data: [DONE]\n\n".to_string());
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\n\
+                 content-length: {}\r\nconnection: close\r\n\r\n{}",
+                payload.len(),
+                payload
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+
+    FakeEndpoint { port }
+}
+
+struct AgentUnderTest {
+    child: Child,
+    stdin: ChildStdin,
+    incoming: Receiver<Value>,
+    next_id: u64,
+}
+
+fn spawn_agent(port: u16, config_dir: &std::path::Path) -> AgentUnderTest {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_sigit"))
+        .env("OPENAI_BASE_URL", format!("http://127.0.0.1:{port}"))
+        .env("OPENAI_API_KEY", "test-key")
+        .env("SIGIT_MODEL", "scripted-model")
+        .env("SIGIT_CONFIG_DIR", config_dir)
+        .env("SIGIT_MCP", "off")
+        .env("SIGIT_PERMISSIONS", "allow")
+        .env_remove("SIGIT_LOCAL_INFERENCE")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sigit in ACP mode");
+
+    let stdout = child.stdout.take().unwrap();
+    let (message_tx, incoming) = channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let Ok(line) = line else { break };
+            if let Ok(message) = serde_json::from_str::<Value>(&line)
+                && message_tx.send(message).is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    let stdin = child.stdin.take().unwrap();
+    AgentUnderTest {
+        child,
+        stdin,
+        incoming,
+        next_id: 0,
+    }
+}
+
+impl AgentUnderTest {
+    fn request(&mut self, method: &str, params: Value) -> u64 {
+        self.next_id += 1;
+        let id = self.next_id;
+        let mut line =
+            json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params}).to_string();
+        line.push('\n');
+        self.stdin.write_all(line.as_bytes()).expect("write stdin");
+        self.stdin.flush().expect("flush stdin");
+        id
+    }
+
+    fn wait_for_response(&mut self, id: u64) -> Value {
+        let deadline = Instant::now() + TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let Ok(message) = self.incoming.recv_timeout(remaining) else {
+                panic!("timed out waiting for the response to request {id}");
+            };
+            if message["id"] == id && message.get("method").is_none() {
+                assert!(
+                    message.get("error").is_none(),
+                    "request {id} failed: {message}"
+                );
+                return message;
+            }
+        }
+    }
+}
+
+impl Drop for AgentUnderTest {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn a_command_that_reads_stdin_cannot_eat_the_clients_next_request() {
+    let scratch = std::env::temp_dir().join(format!("sigit_acp_stdin_{}", std::process::id()));
+    let config_dir = scratch.join("config");
+    let work = scratch.join("work");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&work).unwrap();
+    let stolen = work.join("stolen.txt");
+
+    // A command that drains stdin to a file. With stdin inherited it reads the
+    // JSON-RPC pipe; with stdin closed it gets EOF and exits immediately.
+    let command = format!("cat > {}", stolen.display());
+    let endpoint = start_fake_endpoint(vec![
+        sse_tool_call(
+            "call_1",
+            "run_command",
+            &json!({"command": command, "cwd": work.to_str().unwrap()}).to_string(),
+        ),
+        sse_text("done"),
+        sse_text("still here"),
+    ]);
+
+    let mut agent = spawn_agent(endpoint.port, &config_dir);
+
+    let id = agent.request(
+        "initialize",
+        json!({"protocolVersion": 1, "clientCapabilities": {}}),
+    );
+    agent.wait_for_response(id);
+
+    let id = agent.request("session/new", json!({"cwd": work, "mcpServers": []}));
+    let session_id = agent.wait_for_response(id)["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    let first = agent.request(
+        "session/prompt",
+        json!({"sessionId": session_id, "prompt": [{"type": "text", "text": "commit it"}]}),
+    );
+    agent.wait_for_response(first);
+
+    // The client's next request must reach the agent.
+    let second = agent.request(
+        "session/prompt",
+        json!({"sessionId": session_id, "prompt": [{"type": "text", "text": "and again"}]}),
+    );
+    agent.wait_for_response(second);
+
+    let swallowed = std::fs::read_to_string(&stolen).unwrap_or_default();
+    assert!(
+        swallowed.is_empty(),
+        "the tool's child read {} bytes off the agent's stdin: {swallowed}",
+        swallowed.len()
+    );
+
+    std::fs::remove_dir_all(&scratch).ok();
+}


### PR DESCRIPTION
Fixes the hang reported in getsigit/sigit-si#54.

## What was happening

In ACP mode siGit's stdin is the JSON-RPC pipe from the editor. `run_command` piped stdout and stderr but left stdin inherited, so every shell command it spawned held that pipe open.

A command that reads stdin then does two things. It blocks, because nobody is going to type into the editor's protocol stream. And it reads the client's next request out of the pipe, which is the part that makes the session unrecoverable: the request is consumed, the agent never sees it, and the editor sits waiting for a reply that cannot come. The 120-second command timeout does not help, because the damage is to the protocol stream, not to the command.

In the screenshots on the issue, the command is the release flow's `git commit`, which reaches a signing passphrase prompt. Everything the user typed afterwards, including the model switch and "Continue", went into `git` rather than into siGit.

## The fix

`spawn_shell` sets stdin to null. So do the `git` helpers behind the co-author trailer, and the hook runner in `hooks.rs`, which spawned the same way. A command that wants input now gets EOF and reports an error the model can act on.

Two more things in the same function that also surface as hangs, both fixed here since they are the same "the command never comes back" report:

* **The output pipes were only read after the command exited.** Anything that outgrew the pipe buffer blocked on the write while siGit blocked on the wait, and the 120-second timeout was the only way out. A build or a verbose test run crosses that on its own; 400 KB of `echo` reproduces it in ten seconds. Output is now drained on threads while the command runs, which is the shape `hooks.rs` already uses and documents.
* **The timeout killed the shell and nothing else.** `sh -c` may fork rather than exec, so whatever it started kept running with the pipe write ends open, and the shell itself was never reaped. The child now leads its own process group on Unix and the timeout kills the group.

## Tests

`tests/acp_tool_stdin.rs` drives the real binary over ACP: the scripted endpoint asks for a `run_command` that drains stdin to a file, and the test then sends another request. On the old code it fails by timing out on the first prompt, the same way the editor did. Two unit tests cover the pipe-buffer deadlock and the EOF-on-stdin behaviour.

`cargo fmt -- --check`, `cargo clippy --tests -- -D warnings`, and `cargo test --locked` are green (261 tests). The Windows-target clippy could not run on this machine; the process-group call is the only `cfg`-gated line and the Windows arm is a plain `child.kill()`.

## Not in this PR

The model also emitted a tool call whose title was the raw serialized call, visible as the second card in both screenshots. That is a separate rendering question and does not affect the hang.
