### PR TITLE
Show the endpoint's error message, not the envelope around it

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -116,7 +116,13 @@ feeds results back. Neither the loop nor ACP/TUI surfaces depend on a concrete b
   smbCloud, and stay general otherwise).
 - **`src/backend.rs`** — the `InferenceBackend` trait and neutral types (`ToolSpec`, `ToolCall`,
   `ToolResult`, `TurnResult`). Two impls: `LocalBackend` (on-device via `onde::ChatEngine`) and
-  `OpenAiBackend` (any OpenAI-compatible HTTP endpoint).
+  `OpenAiBackend` (any OpenAI-compatible HTTP endpoint). A `BackendError` is user-facing: the
+  ACP prompt handler passes it to the client verbatim and the editor puts it in an error banner,
+  so `describe_api_error` unwraps the OpenAI `{"error":{"message":…}}` envelope and shows that
+  message on its own, falling back to the status only when there is nothing to unwrap. An
+  endpoint can also fail *after* the response is open, reporting it as a `data:` frame holding
+  the same envelope; that frame has no `choices`, so `consume_stream` has to check for it
+  explicitly or it parses as an empty chunk and the turn ends looking like an empty answer.
 - **`src/provider.rs`** — decides *which* backend serves inference. Resolution order, first match
   wins: (1) override via `OPENAI_BASE_URL`+`OPENAI_API_KEY` or active profile in
   `~/.config/sigit/providers.toml`; (2) siGit Code Cloud when logged in; (3) on-device.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **A refused turn now shows the endpoint's own message.** siGit pasted the
+  status line and the raw JSON body into the editor's error banner, so a
+  billing or allowance message arrived wrapped in
+  `endpoint returned 429 Too Many Requests: {"error":{"message":…`. The message
+  the endpoint wrote is what the banner shows now; the status is only used when
+  there is no message to show
+- **An error that arrives mid-stream is no longer silent.** An endpoint that
+  fails after the response is already open reports it as a frame in the stream.
+  That frame carries no `choices`, so siGit parsed it as an empty chunk and
+  skipped it, and the turn ended as though the model had answered with nothing
+
 ## 1.5.6
 
 ### What changed

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -478,8 +478,8 @@ impl OpenAiBackend {
 
         if !response.status().is_success() {
             let status = response.status();
-            let detail = response.text().await.unwrap_or_default();
-            return Err(format!("endpoint returned {status}: {detail}"));
+            let body = response.text().await.unwrap_or_default();
+            return Err(describe_api_error(status, &body));
         }
 
         if let Some(sink) = sink {
@@ -558,6 +558,16 @@ impl OpenAiBackend {
                 }
                 if data.is_empty() {
                     continue;
+                }
+
+                // An endpoint that fails after the status line is already sent
+                // reports it in the stream instead, as an ordinary `data:`
+                // frame holding an error envelope. siGit Code Cloud does this
+                // when the upstream fails mid-turn. It has no `choices`, so
+                // without this it parses as an empty chunk and is skipped, and
+                // the turn ends looking like the model simply said nothing.
+                if let Some(message) = api_error_message(data) {
+                    return Err(message);
                 }
 
                 let chunk: StreamCompletion = match serde_json::from_str(data) {
@@ -778,6 +788,67 @@ impl InferenceBackend for OpenAiBackend {
     }
 }
 
+// ── OpenAI error shape ────────────────────────────────────────────────────────
+
+/// The OpenAI error envelope: `{"error": {"message": ..., "type": ...}}`.
+///
+/// Every endpoint siGit talks to speaks it, including siGit Code Cloud, whose
+/// messages are written for the person reading them ("Monthly siGit Code Cloud
+/// allowance reached..."). Worth unwrapping rather than pasting the raw body
+/// into the editor's error banner.
+#[derive(Debug, Deserialize)]
+struct ApiErrorEnvelope {
+    error: ApiErrorBody,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiErrorBody {
+    #[serde(default)]
+    message: Option<String>,
+}
+
+/// How much of an unparseable error body to keep. An endpoint behind a proxy
+/// can answer with a full HTML page, and the whole thing ends up in the
+/// editor's error banner.
+const ERROR_BODY_LIMIT: usize = 500;
+
+/// Turn an error response into something worth showing a person.
+///
+/// The endpoint's own message wins when there is one: it is written for the
+/// user, and the status code repeats what it already says. Anything else falls
+/// back to the status plus whatever the body held, which is all there is to go
+/// on.
+fn describe_api_error(status: reqwest::StatusCode, body: &str) -> String {
+    if let Some(message) = api_error_message(body) {
+        return message;
+    }
+
+    let body = body.trim();
+    if body.is_empty() {
+        return format!("endpoint returned {status}");
+    }
+
+    let mut detail = body;
+    if detail.len() > ERROR_BODY_LIMIT {
+        let mut cut = ERROR_BODY_LIMIT;
+        while !detail.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        detail = &detail[..cut];
+        return format!("endpoint returned {status}: {detail}…");
+    }
+    format!("endpoint returned {status}: {detail}")
+}
+
+/// The human-readable message out of an OpenAI error envelope, if the body is
+/// one and carries a non-empty message.
+fn api_error_message(body: &str) -> Option<String> {
+    let envelope: ApiErrorEnvelope = serde_json::from_str(body).ok()?;
+    let message = envelope.error.message?;
+    let message = message.trim();
+    (!message.is_empty()).then(|| message.to_string())
+}
+
 // ── OpenAI response shapes ────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
@@ -966,6 +1037,59 @@ pub async fn adopt_carryover(backend: &dyn InferenceBackend, carried: Vec<serde_
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The case from the issue: the endpoint says something a person can act
+    /// on, and the status code and JSON around it are noise.
+    #[test]
+    fn an_endpoints_own_message_is_what_the_user_sees() {
+        let body = r#"{"error":{"message":"Monthly siGit Code Cloud allowance reached. It resets at the start of your next billing period.","type":"server_error"}}"#;
+
+        let described = describe_api_error(reqwest::StatusCode::TOO_MANY_REQUESTS, body);
+
+        assert_eq!(
+            described,
+            "Monthly siGit Code Cloud allowance reached. \
+             It resets at the start of your next billing period."
+        );
+    }
+
+    #[test]
+    fn a_body_that_is_not_an_error_envelope_keeps_the_status() {
+        let described =
+            describe_api_error(reqwest::StatusCode::BAD_GATEWAY, "<html>bad gateway</html>");
+
+        assert!(described.contains("502"), "{described}");
+        assert!(described.contains("bad gateway"), "{described}");
+    }
+
+    #[test]
+    fn an_empty_body_still_says_something() {
+        let described = describe_api_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, "   ");
+
+        assert_eq!(described, "endpoint returned 500 Internal Server Error");
+    }
+
+    #[test]
+    fn an_oversized_body_is_cut_down() {
+        let body = "x".repeat(ERROR_BODY_LIMIT * 3);
+
+        let described = describe_api_error(reqwest::StatusCode::BAD_GATEWAY, &body);
+
+        assert!(described.len() < ERROR_BODY_LIMIT + 100, "{described}");
+        assert!(described.ends_with('…'), "{described}");
+    }
+
+    /// An envelope with nothing useful in it must not shadow the status, which
+    /// would leave the user with an empty error.
+    #[test]
+    fn an_envelope_with_a_blank_message_falls_back() {
+        let described = describe_api_error(
+            reqwest::StatusCode::FORBIDDEN,
+            r#"{"error":{"message":"  "}}"#,
+        );
+
+        assert!(described.contains("403"), "{described}");
+    }
 
     #[test]
     fn tools_json_wraps_function_schema() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1536,7 +1536,11 @@ impl SiGitAgent {
             .await
             .map_err(|error| {
                 log::error!("send_message_with_tools failed: {error}");
-                agent_client_protocol::Error::new(-32603, format!("inference failed: {error}"))
+                // Verbatim, no prefix: the backend has already turned this into
+                // something worth reading (see `describe_api_error`), and it is
+                // what the editor puts in its error banner. The context a
+                // prefix would add is in the log line above.
+                agent_client_protocol::Error::new(-32603, error)
             })?;
 
         let mut round = 0;
@@ -1734,7 +1738,10 @@ impl SiGitAgent {
                     &mut reply,
                 )
                 .await
-                .map_err(|e| agent_client_protocol::Error::new(-32603, e.to_string()))?;
+                .map_err(|error| {
+                    log::error!("send_tool_results failed: {error}");
+                    agent_client_protocol::Error::new(-32603, error)
+                })?;
         }
 
         // ── Final text response ───────────────────────────────────────────

--- a/tests/acp_endpoint_errors.rs
+++ b/tests/acp_endpoint_errors.rs
@@ -1,0 +1,262 @@
+//! What the editor shows when the endpoint refuses a turn.
+//!
+//! Every endpoint siGit talks to reports failures in the OpenAI error envelope,
+//! and siGit Code Cloud writes those messages for the person reading them
+//! ("Monthly siGit Code Cloud allowance reached…"). The agent used to hand the
+//! raw status line and JSON body to the client, so Zed's error banner showed
+//! the envelope rather than the sentence inside it.
+//!
+//! Two shapes to cover: a failing HTTP status, and an endpoint that only
+//! discovers the problem after the status line is out and reports it as a
+//! `data:` frame in the stream.
+
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpListener;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::Mutex;
+use std::sync::mpsc::{Receiver, channel};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+const TIMEOUT: Duration = Duration::from_secs(30);
+
+const ALLOWANCE_MESSAGE: &str = "Monthly siGit Code Cloud allowance reached. It resets at the start of your next billing period.";
+
+/// One scripted reply per request: an HTTP status plus a body.
+struct Reply {
+    status: &'static str,
+    content_type: &'static str,
+    body: String,
+}
+
+fn error_status_reply() -> Reply {
+    Reply {
+        status: "429 Too Many Requests",
+        content_type: "application/json",
+        body: json!({"error": {"message": ALLOWANCE_MESSAGE, "type": "server_error"}}).to_string(),
+    }
+}
+
+/// A 200 that turns into an error partway through, the way an endpoint has to
+/// report a failure it only sees once the response is already open.
+fn error_in_stream_reply() -> Reply {
+    let frame = json!({"error": {"message": ALLOWANCE_MESSAGE, "type": "server_error"}});
+    Reply {
+        status: "200 OK",
+        content_type: "text/event-stream",
+        body: format!("data: {frame}\n\n"),
+    }
+}
+
+fn start_fake_endpoint(replies: Vec<Reply>) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake endpoint");
+    let port = listener.local_addr().unwrap().port();
+    let queue = Mutex::new(VecDeque::from(replies));
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            let mut reader = BufReader::new(match stream.try_clone() {
+                Ok(clone) => clone,
+                Err(_) => continue,
+            });
+            let mut content_length = 0usize;
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    break;
+                }
+                let line = line.trim();
+                if line.is_empty() {
+                    break;
+                }
+                if let Some(length) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                    content_length = length.trim().parse().unwrap_or(0);
+                }
+            }
+            let mut body = vec![0u8; content_length];
+            if reader.read_exact(&mut body).is_err() {
+                continue;
+            }
+            let reply = queue.lock().unwrap().pop_front().unwrap_or_else(|| Reply {
+                status: "200 OK",
+                content_type: "text/event-stream",
+                body: "data: [DONE]\n\n".to_string(),
+            });
+            let response = format!(
+                "HTTP/1.1 {}\r\ncontent-type: {}\r\ncontent-length: {}\r\n\
+                 connection: close\r\n\r\n{}",
+                reply.status,
+                reply.content_type,
+                reply.body.len(),
+                reply.body
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+
+    port
+}
+
+struct AgentUnderTest {
+    child: Child,
+    stdin: ChildStdin,
+    incoming: Receiver<Value>,
+    next_id: u64,
+}
+
+fn spawn_agent(port: u16, config_dir: &std::path::Path) -> AgentUnderTest {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_sigit"))
+        .env("OPENAI_BASE_URL", format!("http://127.0.0.1:{port}"))
+        .env("OPENAI_API_KEY", "test-key")
+        .env("SIGIT_MODEL", "scripted-model")
+        .env("SIGIT_CONFIG_DIR", config_dir)
+        .env("SIGIT_MCP", "off")
+        .env("SIGIT_PERMISSIONS", "allow")
+        .env_remove("SIGIT_LOCAL_INFERENCE")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sigit in ACP mode");
+
+    let stdout = child.stdout.take().unwrap();
+    let (message_tx, incoming) = channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let Ok(line) = line else { break };
+            if let Ok(message) = serde_json::from_str::<Value>(&line)
+                && message_tx.send(message).is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    let stdin = child.stdin.take().unwrap();
+    AgentUnderTest {
+        child,
+        stdin,
+        incoming,
+        next_id: 0,
+    }
+}
+
+impl AgentUnderTest {
+    fn request(&mut self, method: &str, params: Value) -> u64 {
+        self.next_id += 1;
+        let id = self.next_id;
+        let mut line =
+            json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params}).to_string();
+        line.push('\n');
+        self.stdin.write_all(line.as_bytes()).expect("write stdin");
+        self.stdin.flush().expect("flush stdin");
+        id
+    }
+
+    fn wait_for_message(&mut self, id: u64) -> Value {
+        let deadline = Instant::now() + TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let Ok(message) = self.incoming.recv_timeout(remaining) else {
+                panic!("timed out waiting for the response to request {id}");
+            };
+            if message["id"] == id && message.get("method").is_none() {
+                return message;
+            }
+        }
+    }
+
+    fn wait_for_response(&mut self, id: u64) -> Value {
+        let message = self.wait_for_message(id);
+        assert!(
+            message.get("error").is_none(),
+            "request {id} failed: {message}"
+        );
+        message
+    }
+
+    fn open_session(&mut self, cwd: &std::path::Path) -> String {
+        let id = self.request(
+            "initialize",
+            json!({"protocolVersion": 1, "clientCapabilities": {}}),
+        );
+        self.wait_for_response(id);
+
+        let id = self.request("session/new", json!({"cwd": cwd, "mcpServers": []}));
+        self.wait_for_response(id)["result"]["sessionId"]
+            .as_str()
+            .expect("session id")
+            .to_string()
+    }
+}
+
+impl Drop for AgentUnderTest {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn scratch(name: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("sigit_acp_err_{name}_{}", std::process::id()));
+    std::fs::create_dir_all(dir.join("config")).unwrap();
+    std::fs::create_dir_all(dir.join("work")).unwrap();
+    dir
+}
+
+/// The message the endpoint wrote is the message the client gets: no status
+/// line in front of it, no JSON envelope around it.
+fn assert_is_the_endpoints_message(error: &Value) {
+    let message = error["error"]["message"].as_str().unwrap_or_default();
+    assert_eq!(message, ALLOWANCE_MESSAGE, "full error: {error}");
+}
+
+#[test]
+fn a_refused_turn_reports_the_endpoints_own_message() {
+    let dir = scratch("status");
+    let port = start_fake_endpoint(vec![error_status_reply()]);
+    let mut agent = spawn_agent(port, &dir.join("config"));
+    let session_id = agent.open_session(&dir.join("work"));
+
+    let id = agent.request(
+        "session/prompt",
+        json!({"sessionId": session_id, "prompt": [{"type": "text", "text": "hello"}]}),
+    );
+    let response = agent.wait_for_message(id);
+
+    assert!(
+        response.get("error").is_some(),
+        "expected a failure: {response}"
+    );
+    assert_is_the_endpoints_message(&response);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// An error that arrives as a stream frame used to parse as a chunk with no
+/// choices and get skipped, so the turn ended as if the model had said nothing.
+#[test]
+fn an_error_frame_mid_stream_is_not_swallowed() {
+    let dir = scratch("stream");
+    let port = start_fake_endpoint(vec![error_in_stream_reply()]);
+    let mut agent = spawn_agent(port, &dir.join("config"));
+    let session_id = agent.open_session(&dir.join("work"));
+
+    let id = agent.request(
+        "session/prompt",
+        json!({"sessionId": session_id, "prompt": [{"type": "text", "text": "hello"}]}),
+    );
+    let response = agent.wait_for_message(id);
+
+    assert!(
+        response.get("error").is_some(),
+        "expected a failure: {response}"
+    );
+    assert_is_the_endpoints_message(&response);
+
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
Fixes getsigit/sigit-si#53.

## What the user saw

> **An Error Happened**
> endpoint returned 429 Too Many Requests: {"error":{"message":"Monthly siGit Code Cloud allowance reached. It resets at the start of your next billing period.","type":"server_error"}}

The endpoint had already written a sentence a person can act on. siGit wrapped it in the status line and handed over the raw JSON body, and since a `BackendError` goes to the ACP client verbatim, that whole string is what Zed put in its error banner.

## What this does

`describe_api_error` unwraps the OpenAI `{"error":{"message":…}}` envelope, which every endpoint siGit talks to speaks, and returns the message on its own. Fallbacks, so nothing gets swallowed:

* No envelope, or an envelope with a blank message: the status plus the body, as before.
* A body over 500 bytes: truncated. An endpoint behind a proxy can answer with a full HTML page, and the banner is not the place for it.
* No body at all: `endpoint returned 500 Internal Server Error`.

The prompt handler also stops prefixing `inference failed:`. It put noise in front of a billing message, and the tool-round path next to it never added one, so the same failure read differently depending on when it happened. The context is in the log line either way.

## The half of it that was invisible

An endpoint that fails *after* the response is open cannot use a status, so it reports the error as a `data:` frame in the stream. sigit-si does exactly this when the upstream fails mid-turn.

That frame has no `choices`, and `StreamCompletion::choices` is `#[serde(default)]`, so it parsed cleanly as an empty chunk and got skipped with everything else that has nothing in it. The turn then ended normally and the user got an empty answer with no indication anything had gone wrong. `consume_stream` now checks each frame for an error envelope first.

## Tests

`tests/acp_endpoint_errors.rs` drives the real binary over ACP against an endpoint that refuses the turn, once with a 429 and once with an error frame mid-stream, and asserts the JSON-RPC error message equals the endpoint's sentence exactly. Both fail on the old code; the streaming one fails with `{"stopReason":"end_turn"}` and no error at all, which is the silent case above. Five unit tests cover the fallbacks.

`cargo fmt -- --check`, `cargo clippy --tests -- -D warnings`, and `cargo test --locked` are green (265 tests). Nothing here is `cfg`-gated.

## Not in this PR

sigit-si sends `"type":"server_error"` for the allowance 429, where the OpenAI convention would be something like `insufficient_quota`. siGit does not read the field, so it changes nothing here, but it is worth tidying on that side.

Independent of #71; both touch `CHANGELOG.md`, so whichever lands second needs a trivial merge there.
