### PR TITLE
Render write_todos as an ACP plan update

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,10 +75,11 @@ use agent_client_protocol::schema::v1::{
     ConfigOptionUpdate, ContentBlock, ContentChunk, EmbeddedResourceResource, ForkSessionRequest,
     ForkSessionResponse, Implementation, InitializeRequest, InitializeResponse, LoadSessionRequest,
     LoadSessionResponse, Meta, NewSessionRequest, NewSessionResponse, PermissionOption,
-    PermissionOptionKind, PromptRequest, PromptResponse, RequestPermissionOutcome,
-    RequestPermissionRequest, SessionAdditionalDirectoriesCapabilities, SessionCapabilities,
-    SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption,
-    SessionConfigValueId, SessionForkCapabilities, SessionId, SessionNotification, SessionUpdate,
+    PermissionOptionKind, Plan, PlanEntry, PlanEntryPriority, PlanEntryStatus, PromptRequest,
+    PromptResponse, RequestPermissionOutcome, RequestPermissionRequest,
+    SessionAdditionalDirectoriesCapabilities, SessionCapabilities, SessionConfigOption,
+    SessionConfigOptionCategory, SessionConfigSelectOption, SessionConfigValueId,
+    SessionForkCapabilities, SessionId, SessionNotification, SessionUpdate,
     SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, StopReason, ToolCall,
     ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, UnstructuredCommandInput,
 };
@@ -346,6 +347,35 @@ fn tool_kind_for(tool_name: &str) -> ToolKind {
         "write_todos" => ToolKind::Think,
         _ => ToolKind::Other,
     }
+}
+
+fn todos_arguments_to_plan(arguments: &str) -> Option<Plan> {
+    let args: serde_json::Value = serde_json::from_str(arguments).ok()?;
+    let todos = args.get("todos")?.as_array()?;
+    if todos.is_empty() {
+        return None;
+    }
+
+    let mut entries = Vec::with_capacity(todos.len());
+    for todo in todos {
+        let content = todo.get("content")?.as_str()?.trim();
+        if content.is_empty() {
+            return None;
+        }
+        // Unknown and absent statuses both fall back to pending, matching how
+        // `exec_write_todos` renders them. The two have to agree: the executor
+        // reports success for an off-enum status, so rejecting the plan here
+        // would leave a stale list on screen while the model believes it
+        // reported progress.
+        let status = match todo.get("status").and_then(serde_json::Value::as_str) {
+            Some("completed") => PlanEntryStatus::Completed,
+            Some("in_progress") => PlanEntryStatus::InProgress,
+            _ => PlanEntryStatus::Pending,
+        };
+        entries.push(PlanEntry::new(content, PlanEntryPriority::Medium, status));
+    }
+
+    Some(Plan::new(entries))
 }
 
 /// Shown when a siGit Code Cloud tier is selected without a signed-in account.
@@ -874,6 +904,18 @@ impl SiGitAgent {
         update: SessionUpdate,
     ) -> agent_client_protocol::Result<()> {
         cx.send_notification(SessionNotification::new(session_id, update))
+    }
+
+    fn send_plan_update(
+        &self,
+        cx: &ConnectionTo<Client>,
+        session_id: SessionId,
+        plan: Plan,
+    ) -> agent_client_protocol::Result<()> {
+        cx.send_notification(SessionNotification::new(
+            session_id,
+            SessionUpdate::Plan(plan),
+        ))
     }
 
     /// Advertise siGit's slash commands to the client. Editors like Zed parse
@@ -1609,29 +1651,42 @@ impl SiGitAgent {
                     tc.arguments.chars().take(120).collect::<String>()
                 );
 
-                // Model tool calls are agent actions in ACP too, not merely an
-                // implementation detail of the completion loop. Announce each
-                // one before it runs and close it afterwards so clients such as
-                // Zed can render activity while the next inference round is in
-                // flight. Previously only model loading emitted ToolCall events,
-                // leaving an otherwise working tool round visually indistinct
-                // from a stalled response.
-                let raw_input: serde_json::Value = serde_json::from_str(&tc.arguments)
-                    .unwrap_or_else(|e| {
-                        log::warn!("malformed JSON in tool arguments for '{}': {e}", tc.name);
-                        serde_json::Value::String(tc.arguments.clone())
-                    });
-                self.send_tool_call_update(
-                    cx,
-                    session_id.clone(),
-                    SessionUpdate::ToolCall(
-                        ToolCall::new(tc.id.clone(), tc.name.clone())
-                            .kind(tool_kind_for(&tc.name))
-                            .status(ToolCallStatus::InProgress)
-                            .raw_input(raw_input),
-                    ),
-                )
-                .ok();
+                // Only treat the call as a plan once its arguments have actually
+                // produced one. Keying off the tool name alone means a
+                // `write_todos` the converter rejects sends no plan *and* skips
+                // the tool-call card below, so the call disappears from the
+                // client while the model is told the list was updated.
+                let plan = (tc.name == "write_todos")
+                    .then(|| todos_arguments_to_plan(&tc.arguments))
+                    .flatten();
+                let render_as_plan = plan.is_some();
+                if let Some(plan) = plan {
+                    self.send_plan_update(cx, session_id.clone(), plan).ok();
+                } else {
+                    // Model tool calls are agent actions in ACP too, not merely an
+                    // implementation detail of the completion loop. Announce each
+                    // one before it runs and close it afterwards so clients such as
+                    // Zed can render activity while the next inference round is in
+                    // flight. Previously only model loading emitted ToolCall events,
+                    // leaving an otherwise working tool round visually indistinct
+                    // from a stalled response.
+                    let raw_input: serde_json::Value = serde_json::from_str(&tc.arguments)
+                        .unwrap_or_else(|e| {
+                            log::warn!("malformed JSON in tool arguments for '{}': {e}", tc.name);
+                            serde_json::Value::String(tc.arguments.clone())
+                        });
+                    self.send_tool_call_update(
+                        cx,
+                        session_id.clone(),
+                        SessionUpdate::ToolCall(
+                            ToolCall::new(tc.id.clone(), tc.name.clone())
+                                .kind(tool_kind_for(&tc.name))
+                                .status(ToolCallStatus::InProgress)
+                                .raw_input(raw_input),
+                        ),
+                    )
+                    .ok();
+                }
 
                 let signature = format!("{}\n{}", tc.name, tc.arguments);
                 let repeat_count = repeated_tool_calls
@@ -1727,17 +1782,19 @@ impl SiGitAgent {
 
                 log::info!("  ← {} chars", output.len());
 
-                self.send_tool_call_update(
-                    cx,
-                    session_id.clone(),
-                    SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
-                        tc.id.clone(),
-                        ToolCallUpdateFields::new()
-                            .status(ToolCallStatus::Completed)
-                            .raw_output(serde_json::Value::String(output.clone())),
-                    )),
-                )
-                .ok();
+                if !render_as_plan {
+                    self.send_tool_call_update(
+                        cx,
+                        session_id.clone(),
+                        SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                            tc.id.clone(),
+                            ToolCallUpdateFields::new()
+                                .status(ToolCallStatus::Completed)
+                                .raw_output(serde_json::Value::String(output.clone())),
+                        )),
+                    )
+                    .ok();
+                }
 
                 tool_results.push(BackendToolResult {
                     tool_call_id: tc.id.clone(),

--- a/tests/acp_permissions.rs
+++ b/tests/acp_permissions.rs
@@ -283,6 +283,24 @@ impl AgentUnderTest {
         }
     }
 
+    fn wait_for_prompt_updates(&mut self, id: u64) -> (Value, Vec<Value>) {
+        let mut updates = Vec::new();
+        let deadline = Instant::now() + TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let Ok(message) = self.incoming.recv_timeout(remaining) else {
+                panic!("timed out waiting for the prompt response");
+            };
+            if message["method"] == "session/update" {
+                updates.push(message["params"]["update"].clone());
+            }
+            if message["id"] == id && message.get("method").is_none() {
+                assert!(message.get("error").is_none(), "prompt failed: {message}");
+                return (message, updates);
+            }
+        }
+    }
+
     /// A request *from* the agent (has a `method` and its own id).
     fn wait_for_agent_request(&mut self, method: &str) -> Value {
         self.wait_for(&format!("agent request {method}"), |message| {
@@ -658,6 +676,191 @@ fn a_tool_call_emitted_as_text_is_executed_rather_than_rendered() {
         "history must record the recovered call, not the raw tag: {messages:?}"
     );
     drop(requests);
+
+    drop(agent);
+    let _ = std::fs::remove_dir_all(&scratch);
+}
+
+#[test]
+fn write_todos_reaches_the_client_as_an_acp_plan() {
+    let endpoint = start_fake_endpoint(vec![
+        sse_tool_call(
+            "call_1",
+            "write_todos",
+            &json!({
+                "todos": [
+                    {"content": "Fetch issue screenshot", "status": "completed"},
+                    {"content": "Implement ACP styling", "status": "in_progress"},
+                    {"content": "Build and verify", "status": "pending"}
+                ]
+            })
+            .to_string(),
+        ),
+        sse_text("Continuing."),
+    ]);
+
+    let scratch = std::env::temp_dir().join(format!("sigit_acp_plan_{}", std::process::id()));
+    let config_dir = scratch.join("config");
+    let cwd = scratch.join("cwd");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    let mut agent = spawn_agent(endpoint.port, &config_dir);
+
+    let id = agent.request(
+        "initialize",
+        json!({"protocolVersion": 1, "clientCapabilities": {}}),
+    );
+    agent.wait_for_response(id);
+
+    let id = agent.request("session/new", json!({"cwd": cwd, "mcpServers": []}));
+    let session_id = agent.wait_for_response(id)["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    let prompt_id = agent.request(
+        "session/prompt",
+        json!({
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": "fix the ACP display"}],
+        }),
+    );
+    let (response, updates) = agent.wait_for_prompt_updates(prompt_id);
+    assert_eq!(response["result"]["stopReason"], "end_turn");
+
+    let plan = updates
+        .iter()
+        .find(|update| update["sessionUpdate"] == "plan")
+        .expect("write_todos should be rendered as an ACP plan update");
+    assert_eq!(plan["entries"][0]["content"], "Fetch issue screenshot");
+    assert_eq!(plan["entries"][0]["status"], "completed");
+    assert_eq!(plan["entries"][1]["status"], "in_progress");
+    assert_eq!(plan["entries"][2]["status"], "pending");
+
+    assert!(
+        !updates.iter().any(|update| {
+            update["sessionUpdate"] == "tool_call" && update["title"] == "write_todos"
+        }),
+        "write_todos must not show up as a generic tool-call card: {updates:?}"
+    );
+
+    drop(agent);
+    let _ = std::fs::remove_dir_all(&scratch);
+}
+
+/// An off-enum status must not make the whole call vanish. `exec_write_todos`
+/// renders it as pending and reports success, so the plan has to carry it the
+/// same way; dropping the plan here would leave the client showing a stale list.
+#[test]
+fn write_todos_with_an_unknown_status_still_reaches_the_client() {
+    let endpoint = start_fake_endpoint(vec![
+        sse_tool_call(
+            "call_1",
+            "write_todos",
+            &json!({
+                "todos": [
+                    {"content": "Fetch issue screenshot", "status": "completed"},
+                    {"content": "Ship it", "status": "cancelled"}
+                ]
+            })
+            .to_string(),
+        ),
+        sse_text("Continuing."),
+    ]);
+
+    let scratch = std::env::temp_dir().join(format!("sigit_acp_plan_odd_{}", std::process::id()));
+    let config_dir = scratch.join("config");
+    let cwd = scratch.join("cwd");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    let mut agent = spawn_agent(endpoint.port, &config_dir);
+
+    let id = agent.request(
+        "initialize",
+        json!({"protocolVersion": 1, "clientCapabilities": {}}),
+    );
+    agent.wait_for_response(id);
+
+    let id = agent.request("session/new", json!({"cwd": cwd, "mcpServers": []}));
+    let session_id = agent.wait_for_response(id)["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    let prompt_id = agent.request(
+        "session/prompt",
+        json!({
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": "plan the work"}],
+        }),
+    );
+    let (_response, updates) = agent.wait_for_prompt_updates(prompt_id);
+
+    let plan = updates
+        .iter()
+        .find(|update| update["sessionUpdate"] == "plan")
+        .expect("an unknown status must not drop the plan");
+    assert_eq!(plan["entries"][1]["content"], "Ship it");
+    assert_eq!(plan["entries"][1]["status"], "pending");
+
+    drop(agent);
+    let _ = std::fs::remove_dir_all(&scratch);
+}
+
+/// Arguments the converter cannot turn into a plan fall back to the ordinary
+/// tool-call card. Without that fallback the call is announced nowhere at all.
+#[test]
+fn unconvertible_write_todos_falls_back_to_a_tool_call_card() {
+    let endpoint = start_fake_endpoint(vec![
+        // `todos` is absent, so there is no plan to build. `exec_write_todos`
+        // answers with an error string, and the client still has to see the call.
+        sse_tool_call("call_1", "write_todos", &json!({"items": []}).to_string()),
+        sse_text("Continuing."),
+    ]);
+
+    let scratch = std::env::temp_dir().join(format!("sigit_acp_plan_bad_{}", std::process::id()));
+    let config_dir = scratch.join("config");
+    let cwd = scratch.join("cwd");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    let mut agent = spawn_agent(endpoint.port, &config_dir);
+
+    let id = agent.request(
+        "initialize",
+        json!({"protocolVersion": 1, "clientCapabilities": {}}),
+    );
+    agent.wait_for_response(id);
+
+    let id = agent.request("session/new", json!({"cwd": cwd, "mcpServers": []}));
+    let session_id = agent.wait_for_response(id)["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    let prompt_id = agent.request(
+        "session/prompt",
+        json!({
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": "plan the work"}],
+        }),
+    );
+    let (_response, updates) = agent.wait_for_prompt_updates(prompt_id);
+
+    assert!(
+        !updates
+            .iter()
+            .any(|update| update["sessionUpdate"] == "plan"),
+        "there is no plan to send: {updates:?}"
+    );
+    assert!(
+        updates.iter().any(|update| {
+            update["sessionUpdate"] == "tool_call" && update["title"] == "write_todos"
+        }),
+        "the call must still be announced as a tool call: {updates:?}"
+    );
 
     drop(agent);
     let _ = std::fs::remove_dir_all(&scratch);


### PR DESCRIPTION
Zed and other clients render session/update plans with proper
progress UI, so route the model's write_todos tool calls there
instead of showing them as a generic tool-call card.

Co-Authored-By: siGit Code <noreply@sigit.si>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>