### PR TITLE
Fix compaction failing in every session that ran a tool

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -76,6 +76,51 @@ pub const COMPACT_KEEP_LAST: usize = 6;
 const SUMMARIZE_PROMPT: &str = "Summarize this coding session so far: decisions made, \
     files touched, current state, open items. Be concise and factual.";
 
+/// Render a history snapshot as a plain-text transcript, with tool calls and
+/// tool results spelled out as prose rather than left in their wire shapes.
+///
+/// Compaction summarizes a conversation that is, by definition, thick with
+/// `tool_calls` and `role: "tool"` messages — but the summarization round asks
+/// for a plain answer and so sends no `tools` array. Forwarding the raw shapes
+/// in that request produces tool blocks with no schema to validate against,
+/// which strict endpoints reject outright: Anthropic answers 400, so every
+/// compaction of a session that had ever run a tool failed, permanently, no
+/// matter how small the history was. Flattening to text keeps everything the
+/// summary actually needs and drops the shapes that only make sense alongside
+/// a tool schema. It also sidesteps orphaned `tool_call_id`s and role-
+/// alternation rules, neither of which a transcript can violate.
+fn transcript_for_summary(history: &[serde_json::Value]) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    for message in history {
+        let role = message["role"].as_str().unwrap_or("user");
+        // The system prompt is carried over verbatim, so it needn't be summarized.
+        if role == "system" {
+            continue;
+        }
+
+        let mut parts: Vec<String> = Vec::new();
+        if let Some(text) = message["content"].as_str()
+            && !text.trim().is_empty()
+        {
+            parts.push(text.to_string());
+        }
+        for call in message["tool_calls"].as_array().into_iter().flatten() {
+            parts.push(format!(
+                "called {}({})",
+                call["function"]["name"].as_str().unwrap_or("tool"),
+                call["function"]["arguments"].as_str().unwrap_or_default(),
+            ));
+        }
+        if parts.is_empty() {
+            continue;
+        }
+
+        let label = if role == "tool" { "tool result" } else { role };
+        lines.push(format!("{label}: {}", parts.join("\n")));
+    }
+    lines.join("\n\n")
+}
+
 /// Crude token estimate for a history snapshot: serialized characters / 4.
 /// Deliberately model-agnostic — it only needs to be in the right ballpark to
 /// decide when compaction is worth an extra inference round.
@@ -818,12 +863,30 @@ impl InferenceBackend for OpenAiBackend {
     async fn compact_history(&self, keep_last: usize) -> Result<(), BackendError> {
         let snapshot: Vec<serde_json::Value> = self.history.lock().await.clone();
 
-        // Ask the endpoint for a summary of the conversation so far, through
-        // the ordinary completion machinery (non-streaming).
-        self.history
-            .lock()
-            .await
-            .push(serde_json::json!({ "role": "user", "content": SUMMARIZE_PROMPT }));
+        let system = snapshot
+            .first()
+            .filter(|message| message["role"] == "system")
+            .cloned();
+
+        // Ask the endpoint for a summary of the conversation so far, through the
+        // ordinary completion machinery (non-streaming). The request carries the
+        // conversation as a flattened transcript in a single user message rather
+        // than the live history: this round offers no tools, and a tool-shaped
+        // history sent without a tool schema is rejected upstream (see
+        // `transcript_for_summary`).
+        let mut request = Vec::new();
+        if let Some(system) = system.clone() {
+            request.push(system);
+        }
+        request.push(serde_json::json!({
+            "role": "user",
+            "content": format!(
+                "{}\n\n{SUMMARIZE_PROMPT}",
+                transcript_for_summary(&snapshot),
+            ),
+        }));
+        *self.history.lock().await = request;
+
         let summary = match self.complete(None, None).await {
             Ok(result) => result.text,
             Err(error) => {
@@ -833,10 +896,6 @@ impl InferenceBackend for OpenAiBackend {
             }
         };
 
-        let system = snapshot
-            .first()
-            .filter(|message| message["role"] == "system")
-            .cloned();
         let non_system: Vec<serde_json::Value> = snapshot
             .iter()
             .filter(|message| message["role"] != "system")
@@ -1422,12 +1481,16 @@ mod tests {
     }
 
     /// Minimal scripted OpenAI-compatible endpoint: accepts one HTTP request on
-    /// a std listener and answers with a fixed non-streaming completion.
-    fn spawn_completion_stub(summary: &str) -> std::net::SocketAddr {
+    /// a std listener and answers with a fixed non-streaming completion. The
+    /// receiver yields the request body the backend actually put on the wire.
+    fn spawn_completion_stub(
+        summary: &str,
+    ) -> (std::net::SocketAddr, std::sync::mpsc::Receiver<String>) {
         use std::io::{Read, Write};
 
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
+        let (sender, receiver) = std::sync::mpsc::channel();
         let body = serde_json::json!({
             "choices": [{ "message": { "role": "assistant", "content": summary } }]
         })
@@ -1456,6 +1519,9 @@ mod tests {
                         })
                         .unwrap_or(0);
                     if request.len() >= headers_end + 4 + content_length {
+                        let _ = sender.send(
+                            String::from_utf8_lossy(&request[headers_end + 4..]).into_owned(),
+                        );
                         break;
                     }
                 }
@@ -1468,12 +1534,12 @@ mod tests {
             );
             let _ = stream.write_all(response.as_bytes());
         });
-        addr
+        (addr, receiver)
     }
 
     #[tokio::test]
     async fn compact_history_rebuilds_system_summary_and_tail() {
-        let addr = spawn_completion_stub("We refactored backend.rs; tests pass.");
+        let (addr, _requests) = spawn_completion_stub("We refactored backend.rs; tests pass.");
         let backend = OpenAiBackend::new(
             format!("http://{addr}/v1"),
             "test-key",
@@ -1508,6 +1574,66 @@ mod tests {
             history[3],
             serde_json::json!({ "role": "user", "content": "message 4" })
         );
+    }
+
+    /// Compacting a tool-heavy session must not put tool shapes on the wire.
+    /// The summarization round offers no `tools`, and endpoints reject tool
+    /// calls and tool results that arrive without a schema — which used to make
+    /// compaction fail forever in any session that had run a single tool.
+    #[tokio::test]
+    async fn compact_history_sends_no_tool_artifacts() {
+        let (addr, requests) = spawn_completion_stub("Ran git status on main.");
+        let backend = OpenAiBackend::new(
+            format!("http://{addr}/v1"),
+            "test-key",
+            "test-model",
+            Some("be helpful".into()),
+        );
+        {
+            let mut history = backend.history.lock().await;
+            history.push(serde_json::json!({ "role": "user", "content": "check the repo" }));
+            history.push(serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": { "name": "run_command", "arguments": "{\"command\":\"git status\"}" },
+                }],
+            }));
+            history.push(serde_json::json!({
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "on branch main",
+            }));
+        }
+
+        backend.compact_history(2).await.unwrap();
+
+        let body: serde_json::Value =
+            serde_json::from_str(&requests.recv().unwrap()).expect("request body is JSON");
+        assert!(
+            body.get("tools").is_none(),
+            "summarization offers no tools: {body}"
+        );
+        for message in body["messages"].as_array().unwrap() {
+            assert!(
+                message.get("tool_calls").is_none(),
+                "no tool_calls may be sent without a schema: {message}"
+            );
+            assert_ne!(
+                message["role"], "tool",
+                "no tool results may be sent without a schema: {message}"
+            );
+        }
+
+        // The tool round still has to survive into the summary request as prose,
+        // or the summary loses the work the session actually did.
+        let transcript = body["messages"].as_array().unwrap().last().unwrap()["content"]
+            .as_str()
+            .unwrap();
+        assert!(transcript.contains("called run_command({\"command\":\"git status\"})"));
+        assert!(transcript.contains("tool result: on branch main"));
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1637,7 +1637,19 @@ impl SiGitAgent {
                         let after = backend::estimate_tokens(&backend.history_snapshot().await);
                         log::info!("prompt({}) compacted to ≈{} tokens", session_id, after);
                     }
-                    Err(error) => log::warn!("prompt({}) compaction failed: {error}", session_id),
+                    Err(error) => {
+                        log::warn!("prompt({}) compaction failed: {error}", session_id);
+                        self.send_assistant_message(
+                            cx,
+                            session_id,
+                            format!(
+                                "This session is too large, and siGit Code could not compact it: \
+                                 {error}. Start a new thread or run `/clear`, then retry."
+                            ),
+                        )
+                        .ok();
+                        return Ok(PromptResponse::new(StopReason::EndTurn));
+                    }
                 }
             }
 

--- a/tests/acp_endpoint_errors.rs
+++ b/tests/acp_endpoint_errors.rs
@@ -50,6 +50,34 @@ fn error_in_stream_reply() -> Reply {
     }
 }
 
+fn sse_tool_call(id: &str, name: &str, arguments: &str) -> Reply {
+    Reply {
+        status: "200 OK",
+        content_type: "text/event-stream",
+        body: format!(
+            "data: {}\n\ndata: [DONE]\n\n",
+            json!({
+                "choices": [{"delta": {"tool_calls": [{
+                    "index": 0,
+                    "id": id,
+                    "function": {"name": name, "arguments": arguments},
+                }]}}]
+            })
+        ),
+    }
+}
+
+fn upstream_500_reply() -> Reply {
+    Reply {
+        status: "500 Internal Server Error",
+        content_type: "application/json",
+        body: json!({
+            "error": {"message": "Onde Cloud upstream error (500)", "type": "server_error"}
+        })
+        .to_string(),
+    }
+}
+
 fn start_fake_endpoint(replies: Vec<Reply>) -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake endpoint");
     let port = listener.local_addr().unwrap().port();
@@ -179,6 +207,23 @@ impl AgentUnderTest {
         message
     }
 
+    fn wait_for_prompt_updates(&mut self, id: u64) -> (Value, Vec<Value>) {
+        let mut updates = Vec::new();
+        let deadline = Instant::now() + TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let Ok(message) = self.incoming.recv_timeout(remaining) else {
+                panic!("timed out waiting for the response to request {id}");
+            };
+            if message["method"] == "session/update" {
+                updates.push(message["params"]["update"].clone());
+            }
+            if message["id"] == id && message.get("method").is_none() {
+                return (message, updates);
+            }
+        }
+    }
+
     fn open_session(&mut self, cwd: &std::path::Path) -> String {
         let id = self.request(
             "initialize",
@@ -257,6 +302,55 @@ fn an_error_frame_mid_stream_is_not_swallowed() {
         "expected a failure: {response}"
     );
     assert_is_the_endpoints_message(&response);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn failed_compaction_in_an_oversized_acp_turn_is_reported_as_chat_text() {
+    let dir = scratch("compact");
+    let port = start_fake_endpoint(vec![
+        sse_tool_call(
+            "call_1",
+            "run_command",
+            r#"{"command":"echo should-not-run"}"#,
+        ),
+        upstream_500_reply(),
+    ]);
+    let mut agent = spawn_agent(port, &dir.join("config"));
+    let session_id = agent.open_session(&dir.join("work"));
+
+    let oversized_prompt = "x".repeat(120_000);
+    let id = agent.request(
+        "session/prompt",
+        json!({"sessionId": session_id, "prompt": [{"type": "text", "text": oversized_prompt}]}),
+    );
+    let (response, updates) = agent.wait_for_prompt_updates(id);
+
+    assert!(
+        response.get("error").is_none(),
+        "compaction failure should be a readable chat message, not an ACP error: {response}"
+    );
+    assert_eq!(response["result"]["stopReason"], "end_turn");
+
+    let rendered = updates
+        .iter()
+        .filter_map(|update| {
+            (update["sessionUpdate"] == "agent_message_chunk")
+                .then(|| update["content"]["text"].as_str())
+                .flatten()
+        })
+        .collect::<String>();
+    assert!(
+        rendered.contains("could not compact it: Onde Cloud upstream error (500)"),
+        "wrong rendered message: {rendered:?}"
+    );
+    assert!(
+        !updates
+            .iter()
+            .any(|update| update["sessionUpdate"] == "tool_call"),
+        "tools should not run after compaction fails: {updates:?}"
+    );
 
     std::fs::remove_dir_all(&dir).ok();
 }


### PR DESCRIPTION
compact_history asked for the summary through complete(None, None),
which sends no tools array but left the live history in place. That
history is thick with assistant tool_calls and role:"tool" messages,
and an endpoint handed tool shapes with no schema to check them
against rejects the request. Anthropic answers 400, so compaction
failed on every attempt in any session that had run a single tool, no
matter how small the history was. It then retried on every prompt and
tool round while history kept growing.

Send the conversation as a flattened transcript in one user message
instead. transcript_for_summary renders tool calls and their results
as prose, which keeps what the summary needs and drops the shapes that
only mean anything next to a tool schema. It also avoids orphaned
tool_call_ids and role-alternation rules.

The test stub now hands back the request body it received, so the new
test checks what actually goes on the wire rather than internal state.

Co-Authored-By: siGit Code <noreply@sigit.si>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>