### PR TITLE
Recover tool calls a model emits as text instead of a structured call

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -28,7 +28,8 @@ use tokio::sync::Mutex;
 // ── Neutral types ───────────────────────────────────────────────────────────────
 
 /// A tool the model may call, in a provider-neutral form. `parameters_schema` is
-/// a JSON Schema encoded as a string (matching how siGit already declares tools).
+/// a JSON Schema encoded as a string (matching how siGit Code already declares
+/// tools).
 #[derive(Debug, Clone)]
 pub struct ToolSpec {
     pub name: String,
@@ -482,15 +483,22 @@ impl OpenAiBackend {
             return Err(describe_api_error(status, &body));
         }
 
+        // The specs are needed downstream to type the arguments of any tool
+        // call the model emitted as text rather than as a structured call.
+        let tools = tools.unwrap_or(&[]);
         if let Some(sink) = sink {
-            self.consume_stream(response, sink).await
+            self.consume_stream(response, sink, tools).await
         } else {
-            self.consume_json(response).await
+            self.consume_json(response, tools).await
         }
     }
 
     /// Parse a single non-streaming chat-completion response.
-    async fn consume_json(&self, response: reqwest::Response) -> Result<TurnResult, BackendError> {
+    async fn consume_json(
+        &self,
+        response: reqwest::Response,
+        tools: &[ToolSpec],
+    ) -> Result<TurnResult, BackendError> {
         let parsed: ChatCompletion = response
             .json()
             .await
@@ -515,6 +523,41 @@ impl OpenAiBackend {
             })
             .collect();
 
+        // Some models write a tool call out as literal `<tool_call>` text
+        // instead of using the structured field (see `inline_tool_calls`).
+        // Recover it, or the turn ends with the tag rendered as prose and
+        // whatever the model meant to do is dropped.
+        if tool_calls.is_empty() {
+            let (cleaned, recovered) = crate::inline_tool_calls::extract(&text, tools);
+            if !recovered.is_empty() {
+                log::warn!(
+                    "recovered {} tool call(s) the model emitted as text instead of a structured call",
+                    recovered.len()
+                );
+                let tool_calls: Vec<ToolCall> = recovered
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, call)| ToolCall {
+                        id: format!("call_recovered_{index}"),
+                        name: call.name,
+                        arguments: call.arguments,
+                    })
+                    .collect();
+                // Record the recovered shape, not the raw tag: the tool
+                // results that follow have to answer an assistant message
+                // that actually carries these calls, or the next request is
+                // rejected for orphaned tool results.
+                self.history
+                    .lock()
+                    .await
+                    .push(streamed_assistant_history(&cleaned, &tool_calls));
+                return Ok(TurnResult {
+                    text: cleaned,
+                    tool_calls,
+                });
+            }
+        }
+
         // Record the assistant turn so later tool results have context.
         self.history.lock().await.push(message.into_history_value());
 
@@ -528,6 +571,7 @@ impl OpenAiBackend {
         &self,
         response: reqwest::Response,
         sink: &TokenSink,
+        tools: &[ToolSpec],
     ) -> Result<TurnResult, BackendError> {
         use futures::StreamExt;
 
@@ -538,6 +582,13 @@ impl OpenAiBackend {
         let mut text = String::new();
         let mut tool_accum: Vec<StreamingToolCall> = Vec::new();
         let mut done = false;
+        // Recovers a tool call the model wrote as literal `<tool_call>` text
+        // instead of a structured delta. Scanning here (rather than after the
+        // stream) keeps the tag off the UI: content goes straight to `sink` as
+        // it arrives, so by the time a whole turn is assembled the tag has
+        // already been rendered. See `inline_tool_calls`.
+        let mut scanner = crate::inline_tool_calls::StreamScanner::new(tools);
+        let mut recovered: Vec<ToolCall> = Vec::new();
 
         while let Some(item) = stream.next().await {
             let bytes = item.map_err(|error| format!("stream read error: {error}"))?;
@@ -583,9 +634,31 @@ impl OpenAiBackend {
                 if let Some(content) = choice.delta.content
                     && !content.is_empty()
                 {
-                    text.push_str(&content);
-                    if sink.send(content).is_err() {
-                        // Consumer dropped (turn cancelled) — stop reading.
+                    let mut cancelled = false;
+                    for event in scanner.push(&content) {
+                        match event {
+                            crate::inline_tool_calls::ScanEvent::Text(chunk) => {
+                                text.push_str(&chunk);
+                                if sink.send(chunk).is_err() {
+                                    // Consumer dropped (turn cancelled).
+                                    cancelled = true;
+                                    break;
+                                }
+                            }
+                            crate::inline_tool_calls::ScanEvent::ToolCall(call) => {
+                                log::warn!(
+                                    "recovered tool call '{}' the model emitted as text instead of a structured call",
+                                    call.name
+                                );
+                                recovered.push(ToolCall {
+                                    id: format!("call_recovered_{}", recovered.len()),
+                                    name: call.name,
+                                    arguments: call.arguments,
+                                });
+                            }
+                        }
+                    }
+                    if cancelled {
                         done = true;
                         break;
                     }
@@ -615,7 +688,13 @@ impl OpenAiBackend {
             }
         }
 
-        let tool_calls: Vec<ToolCall> = tool_accum
+        // Text held back waiting on a tag that never closed is just text.
+        if let Some(leftover) = scanner.take_pending() {
+            text.push_str(&leftover);
+            let _ = sink.send(leftover);
+        }
+
+        let mut tool_calls: Vec<ToolCall> = tool_accum
             .iter()
             .filter(|call| !call.name.is_empty())
             .enumerate()
@@ -629,6 +708,7 @@ impl OpenAiBackend {
                 arguments: call.arguments.clone(),
             })
             .collect();
+        tool_calls.extend(recovered);
 
         // Record the assistant turn so later tool results have context.
         self.history

--- a/src/inline_tool_calls.rs
+++ b/src/inline_tool_calls.rs
@@ -1,0 +1,420 @@
+//! Recovery for tool calls a model emits as literal text instead of the
+//! endpoint's structured `tool_calls` field.
+//!
+//! Several open-weight families siGit Code can drive — Qwen 3, GLM, DeepSeek — are
+//! fine-tuned on a chat template that renders a tool call as
+//! `<tool_call>NAME<arg_key>K</arg_key><arg_value>V</arg_value>...</tool_call>`.
+//! A serving stack is supposed to parse that back into the OpenAI-shaped
+//! `tool_calls` field before it reaches us. When it doesn't — seen against the
+//! hosted GLM tiers once the model has just been told a call was rejected as a
+//! repeat (getsigit/sigit#73) — the raw tag arrives as ordinary content.
+//!
+//! Nothing then executes it. Worse, `consume_stream` forwards content to the
+//! UI as it arrives, so the tag is rendered verbatim in the editor and the
+//! turn ends with no tool calls, which reads to the agent loop as "the model
+//! chose to answer in prose". Whatever it was actually trying to do is
+//! dropped.
+//!
+//! This lives here rather than only in the gateway because siGit Code talks to
+//! more than one kind of endpoint: siGit Code Cloud, an arbitrary
+//! OpenAI-compatible base URL from `providers.toml` or `OPENAI_BASE_URL`, and
+//! on-device models. A fix in any single upstream leaves the others exposed.
+//!
+//! Only the well-formed shape is recovered: a flat sequence of key/value pairs
+//! with no nesting. A block that doesn't match is left in the text untouched,
+//! deliberately. Reissuing a `run_command` is cheap, but guessing wrong at a
+//! half-parsed `edit_file` would write the wrong change to a file, so a
+//! malformed block stays visible rather than being silently misinterpreted.
+
+use crate::backend::ToolSpec;
+
+const OPEN_TAG: &str = "<tool_call>";
+const CLOSE_TAG: &str = "</tool_call>";
+
+/// One tool call recovered from inline text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Recovered {
+    pub name: String,
+    /// Arguments as a JSON-encoded string, matching `ToolCall::arguments`.
+    pub arguments: String,
+}
+
+/// Scan a complete text blob for inline tool-call blocks. Returns the text
+/// with recovered blocks removed, plus the calls recovered from them. Blocks
+/// that don't parse cleanly, and an unterminated trailing tag, are left in the
+/// returned text untouched.
+///
+/// `tools` are the specs offered for this turn, used to type each argument
+/// value: a field the schema declares as an integer has to arrive as a JSON
+/// number or the tool's own argument parsing rejects it (`command_output`
+/// reads `task_id` with `as_u64`, which refuses the string `"2"`). Anything
+/// the schema doesn't cover stays a string.
+pub fn extract(text: &str, tools: &[ToolSpec]) -> (String, Vec<Recovered>) {
+    let mut out = String::with_capacity(text.len());
+    let mut calls = Vec::new();
+    let mut cursor = text;
+
+    while let Some(open_idx) = cursor.find(OPEN_TAG) {
+        let Some(close_rel) = cursor[open_idx..].find(CLOSE_TAG) else {
+            // Unterminated tag: leave the rest alone rather than guess at a
+            // block we never saw the end of.
+            break;
+        };
+        let close_idx = open_idx + close_rel;
+        let inner = &cursor[open_idx + OPEN_TAG.len()..close_idx];
+
+        match parse_block(inner, tools) {
+            Some(call) => {
+                out.push_str(&cursor[..open_idx]);
+                calls.push(call);
+            }
+            // Didn't parse cleanly: keep the whole tag as visible text.
+            None => out.push_str(&cursor[..close_idx + CLOSE_TAG.len()]),
+        }
+        cursor = &cursor[close_idx + CLOSE_TAG.len()..];
+    }
+    out.push_str(cursor);
+    (out, calls)
+}
+
+/// Parse one block's inner text: a name, then zero or more
+/// `<arg_key>K</arg_key><arg_value>V</arg_value>` pairs. Returns `None` the
+/// moment anything departs from that shape.
+fn parse_block(inner: &str, tools: &[ToolSpec]) -> Option<Recovered> {
+    let (name, mut rest) = match inner.find("<arg_key>") {
+        Some(idx) => (inner[..idx].trim(), &inner[idx..]),
+        None => (inner.trim(), ""),
+    };
+    if name.is_empty() || name.contains(['<', '>']) {
+        return None;
+    }
+
+    let mut args = serde_json::Map::new();
+    while !rest.is_empty() {
+        let (key, after_key) = split_once(rest.strip_prefix("<arg_key>")?, "</arg_key>")?;
+        let (value, after_value) =
+            split_once(after_key.strip_prefix("<arg_value>")?, "</arg_value>")?;
+        let key = key.trim();
+        if key.is_empty() {
+            return None;
+        }
+        args.insert(
+            key.to_string(),
+            coerce(value, declared_type(tools, name, key).as_deref()),
+        );
+        rest = after_value;
+    }
+
+    Some(Recovered {
+        name: name.to_string(),
+        arguments: serde_json::Value::Object(args).to_string(),
+    })
+}
+
+fn split_once<'a>(s: &'a str, delim: &str) -> Option<(&'a str, &'a str)> {
+    let idx = s.find(delim)?;
+    Some((&s[..idx], &s[idx + delim.len()..]))
+}
+
+/// The JSON Schema `type` declared for `tool_name`'s `key` parameter — e.g.
+/// `"integer"` for `command_output`'s `task_id`. [`ToolSpec`] carries the
+/// schema as an unparsed string, so this parses it per lookup; the argument
+/// counts involved are tiny and this only runs on the recovery path.
+fn declared_type(tools: &[ToolSpec], tool_name: &str, key: &str) -> Option<String> {
+    let spec = tools.iter().find(|spec| spec.name == tool_name)?;
+    let schema: serde_json::Value = serde_json::from_str(&spec.parameters_schema).ok()?;
+    Some(
+        schema
+            .get("properties")?
+            .get(key)?
+            .get("type")?
+            .as_str()?
+            .to_string(),
+    )
+}
+
+/// Convert a raw (unescaped) text value to JSON per its declared schema type.
+/// Falls back to a plain string for `"string"`, an unknown type, or a value
+/// that doesn't parse as what it claims to be. This only ever narrows a value
+/// to what the schema already promises — it never invents structure the text
+/// doesn't have, since a bad coercion would corrupt a call that was otherwise
+/// recoverable.
+fn coerce(raw: &str, declared: Option<&str>) -> serde_json::Value {
+    match declared {
+        Some("integer") => raw
+            .trim()
+            .parse::<i64>()
+            .map(serde_json::Value::from)
+            .unwrap_or_else(|_| serde_json::Value::String(raw.to_string())),
+        Some("number") => raw
+            .trim()
+            .parse::<f64>()
+            .ok()
+            .and_then(serde_json::Number::from_f64)
+            .map(serde_json::Value::Number)
+            .unwrap_or_else(|| serde_json::Value::String(raw.to_string())),
+        Some("boolean") => match raw.trim() {
+            "true" => serde_json::Value::Bool(true),
+            "false" => serde_json::Value::Bool(false),
+            _ => serde_json::Value::String(raw.to_string()),
+        },
+        _ => serde_json::Value::String(raw.to_string()),
+    }
+}
+
+/// One event from incrementally scanning a stream of content deltas.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScanEvent {
+    /// Plain text, safe to forward to the UI.
+    Text(String),
+    /// A tool call recovered from a completed block.
+    ToolCall(Recovered),
+}
+
+/// Incremental scanner for a live delta stream.
+///
+/// Holds back only the text that could still turn into a `<tool_call>` tag, so
+/// ordinary answers — the overwhelming majority of turns, which never contain
+/// one — still reach the UI token by token. Buffering starts only once an
+/// opening tag actually appears, and lasts only until it closes.
+pub struct StreamScanner<'a> {
+    tools: &'a [ToolSpec],
+    pending: String,
+}
+
+impl<'a> StreamScanner<'a> {
+    pub fn new(tools: &'a [ToolSpec]) -> Self {
+        Self {
+            tools,
+            pending: String::new(),
+        }
+    }
+
+    /// Feed the next content delta. Returns events to emit now, in order; may
+    /// be empty if the chunk was absorbed into a tag that hasn't closed yet.
+    pub fn push(&mut self, chunk: &str) -> Vec<ScanEvent> {
+        self.pending.push_str(chunk);
+        self.drain()
+    }
+
+    /// Take whatever is still held back — e.g. a `<tool_call` prefix that
+    /// never closed. Text we never saw the end of can't be interpreted
+    /// safely, so the honest thing is to hand it back as-is, exactly as if
+    /// recovery had never run. Call this wherever the stream can end, or
+    /// held-back text is lost.
+    pub fn take_pending(&mut self) -> Option<String> {
+        if self.pending.is_empty() {
+            None
+        } else {
+            Some(std::mem::take(&mut self.pending))
+        }
+    }
+
+    fn drain(&mut self) -> Vec<ScanEvent> {
+        let mut events = Vec::new();
+        loop {
+            let Some(open_idx) = self.pending.find(OPEN_TAG) else {
+                // No tag yet: flush all but a suffix that could still grow
+                // into "<tool_call>" once the next chunk lands.
+                let keep = partial_prefix_len(&self.pending, OPEN_TAG);
+                let flush_len = self.pending.len() - keep;
+                if flush_len > 0 {
+                    events.push(ScanEvent::Text(
+                        self.pending.drain(..flush_len).collect::<String>(),
+                    ));
+                }
+                break;
+            };
+            if open_idx > 0 {
+                events.push(ScanEvent::Text(
+                    self.pending.drain(..open_idx).collect::<String>(),
+                ));
+            }
+            let Some(close_rel) = self.pending[OPEN_TAG.len()..].find(CLOSE_TAG) else {
+                break; // opened but not closed: wait for more
+            };
+            let close_idx = OPEN_TAG.len() + close_rel;
+            let block: String = self.pending.drain(..close_idx + CLOSE_TAG.len()).collect();
+            let inner = &block[OPEN_TAG.len()..block.len() - CLOSE_TAG.len()];
+            match parse_block(inner, self.tools) {
+                Some(call) => events.push(ScanEvent::ToolCall(call)),
+                None => events.push(ScanEvent::Text(block)),
+            }
+        }
+        events
+    }
+}
+
+/// Length of the longest suffix of `buf` that is a prefix of `needle` — how
+/// much of the tail could still become `needle`. Lets a split opening tag
+/// (one chunk ending `"<tool_c"`, the next starting `"all>"`) be caught
+/// without delaying text that can't possibly be part of one.
+fn partial_prefix_len(buf: &str, needle: &str) -> usize {
+    let max = buf.len().min(needle.len() - 1);
+    for len in (1..=max).rev() {
+        let start = buf.len() - len;
+        if buf.is_char_boundary(start) && needle.starts_with(&buf[start..]) {
+            return len;
+        }
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(name: &str, schema: serde_json::Value) -> ToolSpec {
+        ToolSpec {
+            name: name.to_string(),
+            description: String::new(),
+            parameters_schema: schema.to_string(),
+        }
+    }
+
+    fn command_output_spec() -> ToolSpec {
+        spec(
+            "command_output",
+            serde_json::json!({
+                "type": "object",
+                "properties": { "task_id": { "type": "integer" } }
+            }),
+        )
+    }
+
+    #[test]
+    fn an_integer_argument_is_recovered_as_a_json_number() {
+        // `exec_command_output` reads task_id with `as_u64`, so a string "2"
+        // here would parse as JSON and then fail at the tool.
+        let tools = vec![command_output_spec()];
+        let (text, calls) = extract(
+            "Checking.<tool_call>command_output<arg_key>task_id</arg_key><arg_value>2</arg_value></tool_call>",
+            &tools,
+        );
+        assert_eq!(text, "Checking.");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "command_output");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].arguments).unwrap();
+        assert_eq!(args["task_id"], 2);
+        assert!(args["task_id"].is_number());
+    }
+
+    #[test]
+    fn recovers_multiple_string_arguments_in_order() {
+        let tools = vec![spec(
+            "run_command",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "command": { "type": "string" },
+                    "cwd": { "type": "string" },
+                    "run_in_background": { "type": "boolean" }
+                }
+            }),
+        )];
+        let (text, calls) = extract(
+            "<tool_call>run_command<arg_key>command</arg_key><arg_value>cargo test --locked 2>&1 | tail -20</arg_value><arg_key>cwd</arg_key><arg_value>/Users/x/sigit</arg_value><arg_key>run_in_background</arg_key><arg_value>true</arg_value></tool_call>",
+            &tools,
+        );
+        assert_eq!(text, "");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].arguments).unwrap();
+        assert_eq!(args["command"], "cargo test --locked 2>&1 | tail -20");
+        assert_eq!(args["cwd"], "/Users/x/sigit");
+        assert_eq!(args["run_in_background"], true);
+    }
+
+    #[test]
+    fn a_malformed_block_is_left_alone_rather_than_guessed_at() {
+        // The mis-tagged shape seen in practice: an opening `<arg_value>`
+        // where `<arg_key>` was meant. Guessing at an edit_file call is worse
+        // than leaving it visible.
+        let text = "<tool_call>edit_file<arg_value>new_text</arg_key><arg_value>def x; end</arg_value></tool_call>";
+        let (out, calls) = extract(text, &[]);
+        assert_eq!(out, text);
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn an_unterminated_tag_is_left_alone() {
+        let text = "working on it <tool_call>run_command<arg_key>command</arg_key>";
+        let (out, calls) = extract(text, &[]);
+        assert_eq!(out, text);
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn ordinary_text_passes_through_untouched() {
+        let (out, calls) = extract("if x < y then a<b, nothing to recover", &[]);
+        assert_eq!(out, "if x < y then a<b, nothing to recover");
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn scanner_recovers_a_tag_split_across_chunk_boundaries() {
+        let tools = vec![command_output_spec()];
+        let mut scanner = StreamScanner::new(&tools);
+        let mut text = String::new();
+        let mut calls = Vec::new();
+
+        for chunk in [
+            "polling ",
+            "<tool_c",
+            "all>command_output<arg_",
+            "key>task_id</arg_key><arg_value>2</arg_v",
+            "alue></tool_call>",
+            " done",
+        ] {
+            for event in scanner.push(chunk) {
+                match event {
+                    ScanEvent::Text(t) => text.push_str(&t),
+                    ScanEvent::ToolCall(c) => calls.push(c),
+                }
+            }
+        }
+        if let Some(rest) = scanner.take_pending() {
+            text.push_str(&rest);
+        }
+
+        assert_eq!(text, "polling  done", "no tag fragment may reach the UI");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "command_output");
+    }
+
+    #[test]
+    fn scanner_forwards_ordinary_text_without_holding_it_back() {
+        let mut scanner = StreamScanner::new(&[]);
+        let events = scanner.push("a normal streamed answer");
+        assert_eq!(
+            events,
+            vec![ScanEvent::Text("a normal streamed answer".to_string())]
+        );
+        assert!(scanner.take_pending().is_none());
+    }
+
+    #[test]
+    fn scanner_releases_a_near_miss_prefix_once_it_cannot_match() {
+        let mut scanner = StreamScanner::new(&[]);
+        // "<tool" could still become "<tool_call>", so it is held back...
+        assert_eq!(
+            scanner.push("see <tool"),
+            vec![ScanEvent::Text("see ".to_string())]
+        );
+        // ...and released as soon as the next chunk rules that out.
+        assert_eq!(
+            scanner.push("box for details"),
+            vec![ScanEvent::Text("<toolbox for details".to_string())]
+        );
+        assert!(scanner.take_pending().is_none());
+    }
+
+    #[test]
+    fn scanner_hands_back_an_unclosed_tag_at_stream_end() {
+        let mut scanner = StreamScanner::new(&[]);
+        let events = scanner.push("partial <tool_call>run_command<arg_key>cmd");
+        assert_eq!(events, vec![ScanEvent::Text("partial ".to_string())]);
+        assert_eq!(
+            scanner.take_pending().as_deref(),
+            Some("<tool_call>run_command<arg_key>cmd")
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ mod credentials;
 mod frontmatter;
 mod headless;
 mod hooks;
+mod inline_tool_calls;
 mod instructions;
 mod mcp;
 mod models;

--- a/tests/acp_permissions.rs
+++ b/tests/acp_permissions.rs
@@ -581,3 +581,84 @@ fn text_from_two_tool_rounds_reaches_the_client_as_separate_paragraphs() {
     drop(agent);
     let _ = std::fs::remove_dir_all(&scratch);
 }
+
+/// A model that writes its tool call out as literal `<tool_call>` text instead
+/// of using the structured field must still drive the loop. Before recovery
+/// the tag was streamed to the client as prose and the turn ended with no tool
+/// calls, so the request silently went unanswered (getsigit/sigit#73).
+#[test]
+fn a_tool_call_emitted_as_text_is_executed_rather_than_rendered() {
+    let endpoint = start_fake_endpoint(vec![
+        // Split mid-tag, the way a real stream arrives.
+        sse_body(&[
+            json!({"choices": [{"delta": {"content": "Checking the repo: <tool_c"}}]}),
+            json!({"choices": [{"delta": {"content": "all>command_output<arg_key>task_id</arg_key>"}}]}),
+            json!({"choices": [{"delta": {"content": "<arg_value>2</arg_value></tool_call>"}}]}),
+        ]),
+        sse_text("All done."),
+    ]);
+
+    let scratch = std::env::temp_dir().join(format!("sigit_acp_inline_{}", std::process::id()));
+    let config_dir = scratch.join("config");
+    let cwd = scratch.join("cwd");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    let mut agent = spawn_agent(endpoint.port, &config_dir);
+
+    let id = agent.request(
+        "initialize",
+        json!({"protocolVersion": 1, "clientCapabilities": {}}),
+    );
+    agent.wait_for_response(id);
+
+    let id = agent.request("session/new", json!({"cwd": cwd, "mcpServers": []}));
+    let session_id = agent.wait_for_response(id)["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    let prompt_id = agent.request(
+        "session/prompt",
+        json!({
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": "check the repo"}],
+        }),
+    );
+    let (_response, rendered) = agent.wait_for_prompt(prompt_id);
+
+    // The raw tag must never be shown to the user.
+    assert!(
+        !rendered.contains("<tool_call>") && !rendered.contains("<arg_key>"),
+        "raw tool-call markup reached the client: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("Checking the repo:"),
+        "surrounding prose should still stream: {rendered:?}"
+    );
+
+    // The loop has to keep going: a second request means the recovered call
+    // ran and its result was sent back. Before recovery the turn ended here.
+    let requests = endpoint.requests.lock().unwrap();
+    assert!(
+        requests.len() >= 2,
+        "expected a follow-up request carrying the tool result, got {}",
+        requests.len()
+    );
+    let follow_up = &requests[1];
+    let messages = follow_up["messages"].as_array().expect("messages");
+    assert!(
+        messages.iter().any(|message| message["role"] == "tool"),
+        "the follow-up should answer the recovered call: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|message| { message["role"] == "assistant" && message["tool_calls"].is_array() }),
+        "history must record the recovered call, not the raw tag: {messages:?}"
+    );
+    drop(requests);
+
+    drop(agent);
+    let _ = std::fs::remove_dir_all(&scratch);
+}


### PR DESCRIPTION
Qwen 3, GLM and DeepSeek render a tool call as
<tool_call>NAME<arg_key>K</arg_key>... in their chat template. The serving stack is meant to parse that back into the tool_calls field. When it doesn't, the tag arrives as ordinary content: consume_stream forwards content to the UI as it lands, so the tag was rendered verbatim in the editor, and with no tool calls on the response the turn ended as if the model had chosen to answer in prose. Whatever it meant to do was dropped.

Scan content for those blocks on both the streaming and non-streaming paths, and turn well-formed ones back into real tool calls. The streaming scanner holds back only enough text to catch a tag straddling chunk boundaries, so ordinary answers still stream token by token. Argument values are typed from the turn's own tool schemas, since a field declared integer has to arrive as a JSON number or the tool that runs it rejects the call.

History records the recovered call rather than the raw tag. The tool results that follow have to answer an assistant message that actually carries those calls, or the next request is rejected for orphaned results.

A block that doesn't match the expected shape is left in the text untouched. Reissuing a run_command is cheap, but guessing wrong at a half-parsed edit_file would write the wrong change to a file.

This belongs here and not only in the gateway: siGit Code talks to siGit Code Cloud, to arbitrary OpenAI-compatible endpoints from providers.toml or OPENAI_BASE_URL, and to on-device models. Fixing any one upstream leaves the others exposed.

Fixes #73