### PR TITLE
Replay a loaded session so the thread comes back

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -349,6 +349,107 @@ fn tool_kind_for(tool_name: &str) -> ToolKind {
     }
 }
 
+/// The visible text of one saved history message. `content` is normally a
+/// string, but an OpenAI-compatible endpoint may hand back the block form, and
+/// tool-call-only assistant turns carry `null`.
+fn history_message_text(message: &serde_json::Value) -> String {
+    match &message["content"] {
+        serde_json::Value::String(text) => text.clone(),
+        serde_json::Value::Array(blocks) => blocks
+            .iter()
+            .filter_map(|block| block["text"].as_str())
+            .collect::<Vec<_>>()
+            .join(""),
+        _ => String::new(),
+    }
+}
+
+/// Rebuild the `session/update` notifications that re-draw a saved conversation
+/// in the client.
+///
+/// ACP's `session/load` is a replay: the client renders the reopened thread
+/// purely from the updates the agent streams while the request is in flight.
+/// Restoring history into the backend is what makes the *model* remember, but
+/// it puts nothing on screen, so a reopened session came up blank and looked
+/// like a brand-new one (issue #77).
+fn history_replay_updates(history: &[serde_json::Value]) -> Vec<SessionUpdate> {
+    // Match results to their calls up front so each call replays as one
+    // finished tool call instead of a call followed by a loose result.
+    let mut outputs: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+    for message in history {
+        if message["role"] == "tool"
+            && let (Some(id), Some(content)) = (
+                message["tool_call_id"].as_str(),
+                message["content"].as_str(),
+            )
+        {
+            outputs.insert(id, content);
+        }
+    }
+
+    let mut updates = Vec::new();
+    for message in history {
+        match message["role"].as_str().unwrap_or_default() {
+            // Seeded context and project instructions were never on screen.
+            "system" => {}
+            "user" => {
+                let text = history_message_text(message);
+                if !text.trim().is_empty() {
+                    updates.push(SessionUpdate::UserMessageChunk(ContentChunk::new(
+                        ContentBlock::from(text),
+                    )));
+                }
+            }
+            "assistant" => {
+                let (_think, visible) = chat::strip_think_blocks(&history_message_text(message));
+                if !visible.trim().is_empty() {
+                    updates.push(SessionUpdate::AgentMessageChunk(ContentChunk::new(
+                        ContentBlock::from(visible),
+                    )));
+                }
+                for call in message["tool_calls"].as_array().into_iter().flatten() {
+                    let name = call["function"]["name"].as_str().unwrap_or("tool");
+                    let arguments = call["function"]["arguments"].as_str().unwrap_or("");
+
+                    // `write_todos` renders as a plan while it runs; replay it
+                    // the same way, and let a later list replace an earlier one
+                    // exactly as it did live.
+                    if name == "write_todos"
+                        && let Some(plan) = todos_arguments_to_plan(arguments)
+                    {
+                        updates.push(SessionUpdate::Plan(plan));
+                        continue;
+                    }
+
+                    // A saved call is always finished — nothing is still
+                    // running when the session file is written.
+                    let id = call["id"].as_str().unwrap_or_default();
+                    // A call saved without an id would otherwise collapse into
+                    // one entry per replay; give each its own.
+                    let replay_id = if id.is_empty() {
+                        format!("replay-{}", uuid::Uuid::new_v4())
+                    } else {
+                        id.to_string()
+                    };
+                    let mut tool_call = ToolCall::new(replay_id, name)
+                        .kind(tool_kind_for(name))
+                        .status(ToolCallStatus::Completed)
+                        .raw_input(serde_json::from_str::<serde_json::Value>(arguments).ok());
+                    if let Some(output) = outputs.get(id) {
+                        tool_call =
+                            tool_call.raw_output(serde_json::Value::String((*output).to_string()));
+                    }
+                    updates.push(SessionUpdate::ToolCall(tool_call));
+                }
+            }
+            // Folded into the tool call above.
+            "tool" => {}
+            other => log::debug!("session replay: skipping unknown history role '{other}'"),
+        }
+    }
+    updates
+}
+
 fn todos_arguments_to_plan(arguments: &str) -> Option<Plan> {
     let args: serde_json::Value = serde_json::from_str(arguments).ok()?;
     let todos = args.get("todos")?.as_array()?;
@@ -1273,10 +1374,21 @@ impl SiGitAgent {
         // freshly seeded state wholesale.
         if let Some(history) = session_store::load(&args.session_id.to_string()) {
             let restored = history.len();
+
+            // Replay before restoring: the client draws the reopened thread
+            // from these notifications alone, and `restore_history` consumes
+            // the snapshot.
+            let updates = history_replay_updates(&history);
+            let replayed = updates.len();
+            for update in updates {
+                cx.send_notification(SessionNotification::new(args.session_id.clone(), update))
+                    .ok();
+            }
+
             let backend = self.backend.lock().await.clone();
             backend.restore_history(history).await;
             log::info!(
-                "load_session: restored {restored} message(s) for {}",
+                "load_session: restored {restored} message(s), replayed {replayed} update(s) for {}",
                 args.session_id
             );
         }
@@ -3852,6 +3964,120 @@ mod tests {
         // Relative paths only resolve against the primary root, so the model is
         // told to address the others absolutely.
         assert!(multi.contains("absolute paths"));
+    }
+
+    #[test]
+    fn history_replay_redraws_the_conversation_for_the_client() {
+        let history = vec![
+            serde_json::json!({ "role": "system", "content": "project context" }),
+            serde_json::json!({ "role": "user", "content": "read the changelog" }),
+            serde_json::json!({
+                "role": "assistant",
+                "content": "<think>which file?</think>Reading it now.",
+                "tool_calls": [{
+                    "id": "call_1", "type": "function",
+                    "function": { "name": "read_file", "arguments": "{\"path\":\"/tmp/CHANGELOG.md\"}" },
+                }],
+            }),
+            serde_json::json!({ "role": "tool", "tool_call_id": "call_1", "content": "# Changelog" }),
+            serde_json::json!({ "role": "assistant", "content": "It starts at v1.0." }),
+        ];
+
+        let updates = history_replay_updates(&history);
+
+        // The system message seeded the model; it was never on screen.
+        assert_eq!(updates.len(), 4, "{updates:#?}");
+
+        match &updates[0] {
+            SessionUpdate::UserMessageChunk(chunk) => {
+                assert!(format!("{:?}", chunk.content).contains("read the changelog"));
+            }
+            other => panic!("expected the user message first, got {other:?}"),
+        }
+        match &updates[1] {
+            SessionUpdate::AgentMessageChunk(chunk) => {
+                let rendered = format!("{:?}", chunk.content);
+                assert!(rendered.contains("Reading it now."));
+                // Reasoning stays hidden on replay, exactly as it did live.
+                assert!(!rendered.contains("which file?"));
+            }
+            other => panic!("expected the assistant reply, got {other:?}"),
+        }
+        match &updates[2] {
+            SessionUpdate::ToolCall(call) => {
+                assert_eq!(call.title, "read_file");
+                assert_eq!(call.kind, ToolKind::Read);
+                // Nothing is still running in a saved session.
+                assert_eq!(call.status, ToolCallStatus::Completed);
+                assert_eq!(
+                    call.raw_input,
+                    Some(serde_json::json!({"path": "/tmp/CHANGELOG.md"}))
+                );
+                // The result is folded into its call rather than replayed loose.
+                assert_eq!(
+                    call.raw_output,
+                    Some(serde_json::Value::String("# Changelog".to_string()))
+                );
+            }
+            other => panic!("expected the tool call, got {other:?}"),
+        }
+        assert!(matches!(updates[3], SessionUpdate::AgentMessageChunk(_)));
+    }
+
+    #[test]
+    fn history_replay_renders_write_todos_as_a_plan() {
+        let history = vec![serde_json::json!({
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{
+                "id": "call_1", "type": "function",
+                "function": {
+                    "name": "write_todos",
+                    "arguments": "{\"todos\":[{\"content\":\"Ship it\",\"status\":\"completed\"}]}",
+                },
+            }],
+        })];
+
+        match history_replay_updates(&history).as_slice() {
+            [SessionUpdate::Plan(plan)] => {
+                assert_eq!(plan.entries.len(), 1);
+                assert_eq!(plan.entries[0].content, "Ship it");
+                assert_eq!(plan.entries[0].status, PlanEntryStatus::Completed);
+            }
+            other => panic!("expected one plan update, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn history_replay_skips_messages_with_nothing_to_show() {
+        // A tool-call-only assistant turn (`content: null`), an empty reply and
+        // a blank user message must not become empty bubbles in the client.
+        let history = vec![
+            serde_json::json!({ "role": "user", "content": "   " }),
+            serde_json::json!({ "role": "assistant", "content": null }),
+            serde_json::json!({ "role": "assistant", "content": "" }),
+        ];
+        assert!(history_replay_updates(&history).is_empty());
+    }
+
+    #[test]
+    fn history_replay_reads_block_form_content() {
+        // Some OpenAI-compatible endpoints hand back content blocks rather than
+        // a plain string; both reach the session file.
+        let history = vec![serde_json::json!({
+            "role": "user",
+            "content": [
+                { "type": "text", "text": "check " },
+                { "type": "text", "text": "this file" },
+            ],
+        })];
+
+        match history_replay_updates(&history).as_slice() {
+            [SessionUpdate::UserMessageChunk(chunk)] => {
+                assert!(format!("{:?}", chunk.content).contains("check this file"));
+            }
+            other => panic!("expected one user message, got {other:?}"),
+        }
     }
 
     #[test]

--- a/tests/acp_session_load.rs
+++ b/tests/acp_session_load.rs
@@ -1,0 +1,306 @@
+//! End-to-end check that reopening a saved session redraws it in the client.
+//!
+//! ACP's `session/load` is a replay: the client renders the reopened thread
+//! from the `session/update` notifications the agent streams while the request
+//! is in flight, and keeps nothing of its own. Restoring the history into the
+//! backend is what makes the *model* remember, but it puts nothing on screen —
+//! before this, clicking a thread in Zed's history opened an empty one that
+//! looked brand new (issue #77).
+//!
+//! This drives the real binary against a scripted OpenAI-compatible endpoint:
+//! run one prompt that talks and calls a tool, then load the same session id
+//! and assert the conversation comes back over the wire.
+
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpListener;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::Mutex;
+use std::sync::mpsc::{Receiver, channel};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+const TIMEOUT: Duration = Duration::from_secs(60);
+
+// ── Scripted OpenAI-compatible endpoint ─────────────────────────────────────
+
+fn sse_body(events: &[Value]) -> String {
+    let mut body = String::new();
+    for event in events {
+        body.push_str("data: ");
+        body.push_str(&event.to_string());
+        body.push_str("\n\n");
+    }
+    body.push_str("data: [DONE]\n\n");
+    body
+}
+
+fn sse_text(text: &str) -> String {
+    sse_body(&[json!({"choices": [{"delta": {"content": text}}]})])
+}
+
+fn sse_text_then_tool_call(text: &str, id: &str, name: &str, arguments: &str) -> String {
+    sse_body(&[
+        json!({"choices": [{"delta": {"content": text}}]}),
+        json!({
+            "choices": [{"delta": {"tool_calls": [{
+                "index": 0,
+                "id": id,
+                "function": {"name": name, "arguments": arguments},
+            }]}}]
+        }),
+    ])
+}
+
+/// Serves one scripted SSE response per request.
+fn start_fake_endpoint(responses: Vec<String>) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake endpoint");
+    let port = listener.local_addr().unwrap().port();
+    let queue = Mutex::new(VecDeque::from(responses));
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            let mut reader = BufReader::new(match stream.try_clone() {
+                Ok(clone) => clone,
+                Err(_) => continue,
+            });
+            let mut content_length = 0usize;
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    break;
+                }
+                let line = line.trim();
+                if line.is_empty() {
+                    break;
+                }
+                if let Some(length) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                    content_length = length.trim().parse().unwrap_or(0);
+                }
+            }
+            let mut body = vec![0u8; content_length];
+            if reader.read_exact(&mut body).is_err() {
+                continue;
+            }
+            let payload = queue
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| "data: [DONE]\n\n".to_string());
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\n\
+                 content-length: {}\r\nconnection: close\r\n\r\n{}",
+                payload.len(),
+                payload
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+
+    port
+}
+
+// ── The agent under test ────────────────────────────────────────────────────
+
+struct AgentUnderTest {
+    child: Child,
+    stdin: ChildStdin,
+    incoming: Receiver<Value>,
+    next_id: u64,
+}
+
+fn spawn_agent(port: u16, config_dir: &std::path::Path) -> AgentUnderTest {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_sigit"))
+        .env("OPENAI_BASE_URL", format!("http://127.0.0.1:{port}"))
+        .env("OPENAI_API_KEY", "test-key")
+        .env("SIGIT_MODEL", "scripted-model")
+        .env("SIGIT_CONFIG_DIR", config_dir)
+        .env("SIGIT_MCP", "off")
+        .env("SIGIT_PERMISSIONS", "allow")
+        .env_remove("SIGIT_LOCAL_INFERENCE")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sigit in ACP mode");
+
+    let stdout = child.stdout.take().unwrap();
+    let (message_tx, incoming) = channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let Ok(line) = line else { break };
+            if let Ok(message) = serde_json::from_str::<Value>(&line)
+                && message_tx.send(message).is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    let stdin = child.stdin.take().unwrap();
+    AgentUnderTest {
+        child,
+        stdin,
+        incoming,
+        next_id: 0,
+    }
+}
+
+impl AgentUnderTest {
+    fn request(&mut self, method: &str, params: Value) -> u64 {
+        self.next_id += 1;
+        let id = self.next_id;
+        let mut line =
+            json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params}).to_string();
+        line.push('\n');
+        self.stdin
+            .write_all(line.as_bytes())
+            .expect("write to agent stdin");
+        self.stdin.flush().expect("flush agent stdin");
+        id
+    }
+
+    /// The response to one of our requests, plus every `session/update` that
+    /// arrived before it — which for `session/load` is the whole replay.
+    fn wait_for_response_with_updates(&mut self, id: u64) -> (Value, Vec<Value>) {
+        let mut updates = Vec::new();
+        let deadline = Instant::now() + TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let Ok(message) = self.incoming.recv_timeout(remaining) else {
+                panic!("timed out waiting for the response to request {id}");
+            };
+            if message["method"] == "session/update" {
+                updates.push(message["params"]["update"].clone());
+            }
+            if message["id"] == id && message.get("method").is_none() {
+                assert!(
+                    message.get("error").is_none(),
+                    "request {id} failed: {message}"
+                );
+                return (message, updates);
+            }
+        }
+    }
+}
+
+impl Drop for AgentUnderTest {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn text_of(update: &Value) -> &str {
+    update["content"]["text"].as_str().unwrap_or_default()
+}
+
+#[test]
+fn loading_a_saved_session_replays_it_to_the_client() {
+    let scratch = std::env::temp_dir().join(format!("sigit_acp_load_{}", std::process::id()));
+    let config_dir = scratch.join("config");
+    let project = scratch.join("project");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&project).unwrap();
+    let notes = project.join("notes.md");
+    std::fs::write(&notes, "hello from the notes\n").unwrap();
+
+    // Round 1 talks and reads that file; round 2 answers.
+    let port = start_fake_endpoint(vec![
+        sse_text_then_tool_call(
+            "Let me look at the notes.",
+            "call_1",
+            "read_file",
+            &json!({"path": notes.to_string_lossy()}).to_string(),
+        ),
+        sse_text("The notes say hello."),
+    ]);
+
+    let mut agent = spawn_agent(port, &config_dir);
+
+    let id = agent.request(
+        "initialize",
+        json!({"protocolVersion": 1, "clientCapabilities": {}}),
+    );
+    let (initialize, _) = agent.wait_for_response_with_updates(id);
+    assert_eq!(
+        initialize["result"]["agentCapabilities"]["loadSession"], true,
+        "a client only offers to reopen threads for an agent that advertises loadSession: \
+         {initialize}"
+    );
+
+    let id = agent.request("session/new", json!({"cwd": project, "mcpServers": []}));
+    let (new_session, _) = agent.wait_for_response_with_updates(id);
+    let session_id = new_session["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    let id = agent.request(
+        "session/prompt",
+        json!({
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": "what do the notes say?"}],
+        }),
+    );
+    agent.wait_for_response_with_updates(id);
+
+    // Reopen it, the way clicking the thread in the editor's history does.
+    let id = agent.request(
+        "session/load",
+        json!({"sessionId": session_id, "cwd": project, "mcpServers": []}),
+    );
+    let (_, replay) = agent.wait_for_response_with_updates(id);
+
+    let user: Vec<&str> = replay
+        .iter()
+        .filter(|update| update["sessionUpdate"] == "user_message_chunk")
+        .map(text_of)
+        .collect();
+    assert_eq!(
+        user,
+        vec!["what do the notes say?"],
+        "the user's turn must come back: {replay:#?}"
+    );
+
+    let agent_text: String = replay
+        .iter()
+        .filter(|update| update["sessionUpdate"] == "agent_message_chunk")
+        .map(text_of)
+        .collect();
+    assert!(
+        agent_text.contains("Let me look at the notes.")
+            && agent_text.contains("The notes say hello."),
+        "both rounds of the reply must come back, got {agent_text:?}"
+    );
+
+    let tool_call = replay
+        .iter()
+        .find(|update| update["sessionUpdate"] == "tool_call")
+        .unwrap_or_else(|| panic!("the tool call must come back: {replay:#?}"));
+    assert_eq!(tool_call["title"], "read_file");
+    // Nothing is still running in a saved session, and the result is folded
+    // back into its call rather than replayed as a loose message.
+    assert_eq!(tool_call["status"], "completed");
+    assert!(
+        tool_call["rawOutput"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("hello from the notes"),
+        "the tool result must ride along with its call: {tool_call}"
+    );
+
+    // The seeded system context is the model's, not the user's — it must never
+    // surface as a message in the thread.
+    for update in &replay {
+        assert!(
+            !text_of(update).contains("project working directory"),
+            "system context leaked into the replay: {update}"
+        );
+    }
+
+    drop(agent);
+    let _ = std::fs::remove_dir_all(&scratch);
+}


### PR DESCRIPTION
Reopening a saved thread in Zed opened an empty one that looked like a new conversation (#77). Also fixes https://sigit.si/sigit/sigit/issues/11

`session/load` is a replay in ACP: the client renders the reopened thread from the `session/update` notifications the agent streams while the request is still in flight, and keeps nothing of its own. Our handler restored the saved history into the backend, which is what makes the model remember the conversation, and sent the client nothing. The model had the thread, the editor showed a blank page. Zed's own log confirms it, `load_session: restored 192 message(s)` with no updates behind it.

`history_replay_updates` now turns the saved snapshot into notifications, and `handle_load_session` sends them before restoring the history:

* user and assistant text replay as message chunks, with `<think>` blocks stripped the same way they are stripped live
* a tool call replays as one completed `tool_call` carrying its arguments and its result, instead of a call plus a loose result message
* `write_todos` replays as a plan, so a reopened thread shows the todo list rather than a raw tool call
* system messages are skipped, since they seeded the model and were never on screen

Fork still starts clean. It never had persistence to begin with, and that is worth a separate look.

## Testing

`tests/acp_session_load.rs` drives the real binary against a scripted endpoint: one prompt that talks and reads a file, then `session/load` on the same session id, asserting the user turn, both rounds of the reply and the completed tool call with its output come back. It fails on `development` and passes here. Four unit tests cover the snapshot to update mapping, including empty messages, block form content and the plan case.

Also checked by hand against a real 192 message session file from `~/.config/sigit/sessions`: 8 user chunks, 41 agent chunks, 83 tool calls and 7 plans replayed.

`cargo fmt --check`, `cargo clippy --tests -- -D warnings` and `cargo test --locked` are all green.