### PR TITLE
Add ACP permission mode selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### What changed
 
+- **Editor panels can switch permission mode without a slash command.** ACP
+  clients now get a Permissions selector next to the model controls with
+  Manual, Auto, and Plan choices for the current session. Manual keeps the
+  existing approval prompts, Auto lets mutating tools run unattended while
+  still respecting explicit deny rules in `settings.toml`, and Plan keeps the
+  agent in research-only mode. The selector follows `/plan` and `/clear`, and
+  it is deliberately session-scoped so a risky Auto choice does not persist
+  into the next task
 - **`@smbcloud/sigit` gets releases again.** The npm scope moved to
   `@getsigit` in 1.5.5 and the old package was left sitting on the registry at
   1.5.2, so an install made before the rename went quiet — `npm update` had

--- a/src/main.rs
+++ b/src/main.rs
@@ -1395,7 +1395,7 @@ impl SiGitAgent {
 
         let config_options = {
             let guard = self.current_model.lock().unwrap();
-            build_model_config_options(&guard)
+            build_config_options(&guard, &args.session_id.to_string())
         };
 
         self.advertise_commands(cx, args.session_id.clone());
@@ -1444,7 +1444,7 @@ impl SiGitAgent {
 
         let config_options = {
             let guard = self.current_model.lock().unwrap();
-            build_model_config_options(&guard)
+            build_config_options(&guard, &new_id.to_string())
         };
 
         self.advertise_commands(cx, new_id.clone());
@@ -1491,7 +1491,7 @@ impl SiGitAgent {
 
         let config_options = {
             let guard = self.current_model.lock().unwrap();
-            build_model_config_options(&guard)
+            build_config_options(&guard, &session_id.to_string())
         };
 
         self.advertise_commands(cx, session_id.clone());
@@ -2241,7 +2241,7 @@ impl SiGitAgent {
         // Push refreshed picker + commands so the editor reflects current state.
         let config_options = {
             let guard = self.current_model.lock().unwrap();
-            build_model_config_options(&guard)
+            build_config_options(&guard, &session_id.to_string())
         };
         self.send_tool_call_update(
             cx,
@@ -2297,7 +2297,46 @@ impl SiGitAgent {
                 .ok();
             // Rebuild so the Model picker reflects the new emphasis/order.
             let current = self.current_model.lock().unwrap().clone();
-            let config_options = build_model_config_options(&current);
+            let config_options = build_config_options(&current, &args.session_id.to_string());
+            return Ok(SetSessionConfigOptionResponse::new(config_options));
+        }
+
+        // ── Permissions dropdown (issue #76) ────────────────────────────────
+        if args.config_id.0.as_ref() == PERMISSION_MODE_CONFIG_ID {
+            let session_key = args.session_id.to_string();
+            let message = match args.value.as_value_id().map(|v| v.0.as_ref()) {
+                Some(PERMISSION_MODE_MANUAL) => {
+                    permissions::set_plan_mode(&session_key, false);
+                    permissions::set_session_mode(
+                        &session_key,
+                        Some(settings::PermissionMode::Ask),
+                    );
+                    "Permissions: Manual — the agent asks before running mutating tools."
+                }
+                Some(PERMISSION_MODE_AUTO) => {
+                    permissions::set_plan_mode(&session_key, false);
+                    permissions::set_session_mode(
+                        &session_key,
+                        Some(settings::PermissionMode::Allow),
+                    );
+                    "Permissions: Auto — tools run without asking, subject to settings.toml rules."
+                }
+                Some(PERMISSION_MODE_PLAN) => {
+                    permissions::set_plan_mode(&session_key, true);
+                    "Permissions: Plan — the agent researches with read-only tools and presents \
+                     a plan; edits and commands are blocked."
+                }
+                other => {
+                    return Err(agent_client_protocol::Error::new(
+                        -32602,
+                        format!("unknown Permissions value: {other:?}"),
+                    ));
+                }
+            };
+            self.send_system_status(cx, args.session_id.clone(), message)
+                .ok();
+            let current = self.current_model.lock().unwrap().clone();
+            let config_options = build_config_options(&current, &session_key);
             return Ok(SetSessionConfigOptionResponse::new(config_options));
         }
 
@@ -2341,7 +2380,7 @@ impl SiGitAgent {
                     "set_session_config_option: {} is already the active selection, skipping",
                     current.display_name
                 );
-                let config_options = build_model_config_options(&current);
+                let config_options = build_config_options(&current, &args.session_id.to_string());
                 return Ok(SetSessionConfigOptionResponse::new(config_options));
             }
         }
@@ -2371,7 +2410,7 @@ impl SiGitAgent {
             }
 
             let current = self.current_model.lock().unwrap().clone();
-            let config_options = build_model_config_options(&current);
+            let config_options = build_config_options(&current, &args.session_id.to_string());
             return Ok(SetSessionConfigOptionResponse::new(config_options));
         }
 
@@ -2608,7 +2647,7 @@ impl SiGitAgent {
 
                 let config_options = {
                     let guard = self.current_model.lock().unwrap();
-                    build_model_config_options(&guard)
+                    build_config_options(&guard, &args.session_id.to_string())
                 };
 
                 log::info!("model switch complete");
@@ -2648,6 +2687,16 @@ const LOCAL_INFERENCE_CONFIG_ID: &str = "sigit-local-inference";
 const LOCAL_INFERENCE_ON: &str = "local-inference-on";
 const LOCAL_INFERENCE_OFF: &str = "local-inference-off";
 
+/// config option ID for the Permissions dropdown (issue #76): flips the
+/// session between asking for approval, running tools unattended, and plan
+/// mode, without touching `settings.toml`.
+const PERMISSION_MODE_CONFIG_ID: &str = "sigit-permission-mode";
+
+/// `select` value ids for the Permissions dropdown.
+const PERMISSION_MODE_MANUAL: &str = "permission-mode-manual";
+const PERMISSION_MODE_AUTO: &str = "permission-mode-auto";
+const PERMISSION_MODE_PLAN: &str = "permission-mode-plan";
+
 /// Replace non-ASCII chars so a downstream byte-index truncation can't split a
 /// multi-byte char. Zed slices the model-picker label at a fixed byte offset
 /// (`agent_ui/src/config_options.rs`) and panics — crashing the whole editor —
@@ -2659,7 +2708,10 @@ fn ascii_safe(s: &str) -> String {
         .collect()
 }
 
-fn build_model_config_options(current_model: &GgufModelConfig) -> Vec<SessionConfigOption> {
+fn build_config_options(
+    current_model: &GgufModelConfig,
+    session_key: &str,
+) -> Vec<SessionConfigOption> {
     // The full list, including the siGit Code Cloud tiers, so the panel picker
     // mirrors the TUI `/models`. Cloud entries are sign-in gated at selection.
     let items = models::build_model_picker_items();
@@ -2749,8 +2801,46 @@ fn build_model_config_options(current_model: &GgufModelConfig) -> Vec<SessionCon
     )
     .description("Toggle on-device inference; changes which models are highlighted");
 
+    // Permissions dropdown (issue #76): Manual (ask), Auto (run unattended),
+    // Plan (research only). Derived, never stored — see `permissions.rs`.
+    let permission_current = SessionConfigValueId::new(if permissions::plan_mode(session_key) {
+        PERMISSION_MODE_PLAN
+    } else {
+        match permissions::effective_mode(session_key) {
+            settings::PermissionMode::Allow => PERMISSION_MODE_AUTO,
+            settings::PermissionMode::Ask | settings::PermissionMode::Deny => {
+                PERMISSION_MODE_MANUAL
+            }
+        }
+    });
+    let permission_options = vec![
+        SessionConfigSelectOption::new(
+            SessionConfigValueId::new(PERMISSION_MODE_MANUAL),
+            "Manual".to_string(),
+        )
+        .description("Ask before running mutating tools".to_string()),
+        SessionConfigSelectOption::new(
+            SessionConfigValueId::new(PERMISSION_MODE_AUTO),
+            "Auto".to_string(),
+        )
+        .description("Run tools without asking, subject to settings.toml rules".to_string()),
+        SessionConfigSelectOption::new(
+            SessionConfigValueId::new(PERMISSION_MODE_PLAN),
+            "Plan".to_string(),
+        )
+        .description("Research only; no edits or commands".to_string()),
+    ];
+    let permission_option = SessionConfigOption::select(
+        PERMISSION_MODE_CONFIG_ID,
+        "Permissions",
+        permission_current,
+        permission_options,
+    )
+    .category(SessionConfigOptionCategory::Mode)
+    .description("How tool calls are approved for this session");
+
     if options.is_empty() {
-        return vec![local_option];
+        return vec![local_option, permission_option];
     }
 
     let current_value = SessionConfigValueId::new(current_model.model_id.as_str());
@@ -2760,6 +2850,7 @@ fn build_model_config_options(current_model: &GgufModelConfig) -> Vec<SessionCon
             .category(SessionConfigOptionCategory::Model)
             .description("Select an on-device model or a siGit Code Cloud tier"),
         local_option,
+        permission_option,
     ]
 }
 
@@ -2970,6 +3061,19 @@ async fn exec_slash_acp(
             permissions::reset_session(&session_id.to_string());
             // The saved session must not resurrect what the user just wiped.
             session_store::delete(&session_id.to_string());
+            // The wipe drops the session's Permissions override too; push the
+            // refreshed chip so it doesn't keep showing a stale pick.
+            let config_options = {
+                let current = agent.current_model.lock().unwrap();
+                build_config_options(&current, &session_id.to_string())
+            };
+            agent
+                .send_tool_call_update(
+                    cx,
+                    session_id.clone(),
+                    SessionUpdate::ConfigOptionUpdate(ConfigOptionUpdate::new(config_options)),
+                )
+                .ok();
             agent
                 .send_assistant_message(
                     cx,
@@ -2989,6 +3093,19 @@ async fn exec_slash_acp(
                 "Plan mode OFF — the agent may execute tools again (subject to the \
                  permission policy)."
             };
+            // Keep the panel Permissions chip in step: /plan on moves it to
+            // Plan, /plan off drops it back to whatever the session mode is.
+            let config_options = {
+                let current = agent.current_model.lock().unwrap();
+                build_config_options(&current, &session_key)
+            };
+            agent
+                .send_tool_call_update(
+                    cx,
+                    session_id.clone(),
+                    SessionUpdate::ConfigOptionUpdate(ConfigOptionUpdate::new(config_options)),
+                )
+                .ok();
             agent.send_assistant_message(cx, session_id, message).ok();
         }
         SlashCommand::Permissions => {
@@ -3175,7 +3292,7 @@ async fn exec_slash_acp(
             // Refresh the panel so the Model picker reflects the new emphasis.
             let config_options = {
                 let current = agent.current_model.lock().unwrap();
-                build_model_config_options(&current)
+                build_config_options(&current, &session_id.to_string())
             };
             agent
                 .send_tool_call_update(
@@ -4229,7 +4346,7 @@ mod tests {
             approx_memory: "Cloud".to_string(),
             chat_template: None,
         };
-        let options = serde_json::to_value(build_model_config_options(&current)).unwrap();
+        let options = serde_json::to_value(build_config_options(&current, "t-config")).unwrap();
         let all_options = options.as_array().expect("config options");
 
         let model = all_options
@@ -4265,5 +4382,19 @@ mod tests {
             .filter_map(|option| option["name"].as_str())
             .collect();
         assert_eq!(inference_names, ["Local", "Cloud"]);
+
+        let permissions = all_options
+            .iter()
+            .find(|option| option["id"] == PERMISSION_MODE_CONFIG_ID)
+            .expect("permissions config option");
+        assert_eq!(permissions["category"], "mode");
+        assert_eq!(permissions["currentValue"], PERMISSION_MODE_MANUAL);
+        let permission_names: Vec<&str> = permissions["options"]
+            .as_array()
+            .expect("permissions select options")
+            .iter()
+            .filter_map(|option| option["name"].as_str())
+            .collect();
+        assert_eq!(permission_names, ["Manual", "Auto", "Plan"]);
     }
 }

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -8,7 +8,7 @@
 //!
 //! 1. **Plan mode** — a per-session switch that denies every mutating tool with
 //!    a message telling the model to present a plan instead. Toggled via
-//!    `/plan on|off` (TUI and ACP).
+//!    `/plan on|off` (TUI and ACP) or the panel Permissions dropdown.
 //! 2. **Session grants** — "always allow this session", recorded when the user
 //!    picks that option in an approval prompt. For `run_command` the grant is
 //!    scoped to the command's first two whitespace-separated tokens (approving
@@ -24,8 +24,11 @@
 //!    before `allow`, so a deny always beats an allow matching the same call.
 //! 4. **Per-tool override** — `[permissions.tools]` in `settings.toml`, e.g.
 //!    `run_command = "ask"`, `edit_file = "allow"`, `delete_file = "deny"`.
-//! 5. **Default mode** — `[permissions] default = "ask"|"allow"|"deny"` in
-//!    `settings.toml`; `ask` on a fresh install.
+//! 5. **Session mode (panel dropdown), else the stored default** — the ACP
+//!    panel's Permissions selector (`Manual`/`Auto`) picks a
+//!    [`settings::PermissionMode`] for the session, stored beside `plan_mode`;
+//!    with no session override, `[permissions] default = "ask"|"allow"|"deny"`
+//!    in `settings.toml` applies (`ask` on a fresh install).
 //!
 //! Pattern matching (rules and session grants share it): `*` is a glob-style
 //! wildcard (the `glob` tool's translator). A pattern ending in `*` matches
@@ -133,6 +136,9 @@ struct SessionPerms {
     always_allow: HashSet<String>,
     /// When set, every mutating tool is denied with a plan-mode message.
     plan_mode: bool,
+    /// Session override picked from the panel Permissions dropdown. `None`
+    /// means "use the stored default" (see [`effective_mode`]).
+    mode: Option<PermissionMode>,
 }
 
 fn sessions() -> &'static Mutex<HashMap<String, SessionPerms>> {
@@ -312,7 +318,11 @@ pub fn decision_for(session: &str, tool_name: &str, arguments: &str) -> Decision
         return Decision::Allow;
     }
 
-    match settings::permission_mode_for(tool_name) {
+    let mode = match settings::permission_mode_explicit(tool_name) {
+        Some(explicit) => explicit,
+        None => with_session(session, |s| s.mode).unwrap_or_else(settings::permission_default),
+    };
+    match mode {
         PermissionMode::Allow => Decision::Allow,
         PermissionMode::Ask => Decision::Ask,
         PermissionMode::Deny => Decision::Deny(format!(
@@ -363,6 +373,25 @@ pub fn plan_mode(session: &str) -> bool {
     with_session(session, |s| s.plan_mode)
 }
 
+/// Set (or clear) the session's permission-mode override, picked from the
+/// panel Permissions dropdown. `None` reverts the session to the stored
+/// default (see [`effective_mode`]).
+pub fn set_session_mode(session: &str, mode: Option<PermissionMode>) {
+    with_session(session, |s| s.mode = mode);
+}
+
+/// The session's permission-mode override, if one was picked from the panel
+/// dropdown. `None` means the session follows the stored default.
+pub fn session_mode(session: &str) -> Option<PermissionMode> {
+    with_session(session, |s| s.mode)
+}
+
+/// The permission mode that actually governs this session: its dropdown
+/// override when set, else `settings::permission_default()`.
+pub fn effective_mode(session: &str) -> PermissionMode {
+    session_mode(session).unwrap_or_else(settings::permission_default)
+}
+
 /// Drop all recorded state for a session (fresh session, /clear, or session
 /// teardown) so grants never outlive the conversation they were given in.
 pub fn reset_session(session: &str) {
@@ -384,11 +413,16 @@ pub fn reset_all() {
     map.clear();
 }
 
-/// Status summary for `/permissions` and `/status`: the default mode, plan
-/// mode, the granular session grants, and the active rule lists.
+/// Status summary for `/permissions` and `/status`: the default mode, the
+/// session mode override (if any), plan mode, the granular session grants,
+/// and the active rule lists.
 pub fn describe(session: &str) -> String {
     let plan = if plan_mode(session) { "on" } else { "off" };
     let default = settings::permission_default();
+    let mode = match session_mode(session) {
+        Some(mode) => format!("{mode} (session override)"),
+        None => format!("{default} (stored default)"),
+    };
     let granted = with_session(session, |s| {
         let mut names: Vec<&str> = s.always_allow.iter().map(String::as_str).collect();
         names.sort_unstable();
@@ -408,7 +442,7 @@ pub fn describe(session: &str) -> String {
         }
     };
     format!(
-        "permissions: default={default} | plan mode: {plan} | session grants: {granted}\n\
+        "permissions: mode={mode} | plan mode: {plan} | session grants: {granted}\n\
          rules: deny: {} | allow: {}\n\
          read-only tools always run; configure [permissions] in settings.toml",
         render(&rules.deny),
@@ -779,6 +813,97 @@ mod tests {
         assert_eq!(run_command_decision(session, "ls -la"), Decision::Allow);
         assert_eq!(run_command_decision(session, "lsof"), Decision::Ask);
         reset_session(session);
+    }
+
+    #[test]
+    fn session_mode_overrides_default_mode() {
+        let _guard = env_guard();
+        let session = "t-mode";
+        reset_session(session);
+        assert_eq!(effective_mode(session), PermissionMode::Ask);
+        assert_eq!(run_command_decision(session, "cargo test"), Decision::Ask);
+
+        set_session_mode(session, Some(PermissionMode::Allow));
+        assert_eq!(effective_mode(session), PermissionMode::Allow);
+        assert_eq!(run_command_decision(session, "cargo test"), Decision::Allow);
+
+        set_session_mode(session, None);
+        assert_eq!(effective_mode(session), PermissionMode::Ask);
+        assert_eq!(run_command_decision(session, "cargo test"), Decision::Ask);
+        reset_session(session);
+    }
+
+    #[test]
+    fn explicit_tool_override_beats_session_mode() {
+        let _guard = env_guard();
+        let session = "t-mode-override";
+        reset_session(session);
+        set_session_mode(session, Some(PermissionMode::Allow));
+
+        let mut settings = settings::load();
+        settings
+            .permissions
+            .tools
+            .insert("delete_file".to_string(), PermissionMode::Deny);
+        settings::store(&settings).unwrap();
+
+        assert!(matches!(
+            decision_for(session, "delete_file", r#"{"path":"src/a.rs"}"#),
+            Decision::Deny(_)
+        ));
+        assert_eq!(
+            run_command_decision(session, "cargo test"),
+            Decision::Allow,
+            "run_command has no explicit override, so the session mode applies"
+        );
+        reset_session(session);
+    }
+
+    #[test]
+    fn deny_rule_beats_session_mode() {
+        let _guard = env_guard();
+        let session = "t-mode-deny-rule";
+        reset_session(session);
+        set_session_mode(session, Some(PermissionMode::Allow));
+        store_rules(&[], &["run_command(git push*)"]);
+
+        assert!(matches!(
+            run_command_decision(session, "git push"),
+            Decision::Deny(_)
+        ));
+        assert_eq!(
+            run_command_decision(session, "git status"),
+            Decision::Allow,
+            "an unmatched command still follows the session mode"
+        );
+        reset_session(session);
+    }
+
+    #[test]
+    fn plan_mode_outranks_session_mode() {
+        let _guard = env_guard();
+        let session = "t-mode-plan";
+        reset_session(session);
+        set_session_mode(session, Some(PermissionMode::Allow));
+        set_plan_mode(session, true);
+        assert!(matches!(
+            run_command_decision(session, "cargo test"),
+            Decision::Deny(_)
+        ));
+        set_plan_mode(session, false);
+        reset_session(session);
+    }
+
+    #[test]
+    fn reset_session_clears_session_mode() {
+        let _guard = env_guard();
+        let session = "t-mode-reset";
+        reset_session(session);
+        set_session_mode(session, Some(PermissionMode::Allow));
+        assert_eq!(session_mode(session), Some(PermissionMode::Allow));
+        reset_session(session);
+        assert_eq!(session_mode(session), None);
+        assert_eq!(effective_mode(session), PermissionMode::Ask);
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -230,26 +230,11 @@ pub fn permission_rules() -> PermissionRules {
 }
 
 /// The tool's explicit `[permissions.tools]` override, or `None` when it has
-/// no entry. Unlike [`permission_mode_for`] this never falls back to the
-/// default or the env override, so callers can tell "the user set a mode for
-/// this exact tool" apart from "the tool inherits the default".
+/// no entry. This never falls back to the default or the env override, so
+/// callers can tell "the user set a mode for this exact tool" apart from "the
+/// tool inherits the default".
 pub fn permission_mode_explicit(tool_name: &str) -> Option<PermissionMode> {
     load().permissions.tools.get(tool_name).copied()
-}
-
-/// The effective permission mode for one tool: its `[permissions.tools]`
-/// override when present, else the default (see [`permission_default`]).
-pub fn permission_mode_for(tool_name: &str) -> PermissionMode {
-    let settings = load();
-    if let Some(mode) = settings.permissions.tools.get(tool_name) {
-        return *mode;
-    }
-    if let Ok(raw) = std::env::var(PERMISSIONS_ENV)
-        && let Some(mode) = PermissionMode::parse(&raw)
-    {
-        return mode;
-    }
-    settings.permissions.default
 }
 
 #[cfg(test)]
@@ -295,7 +280,7 @@ mod tests {
         // overrides.
         unsafe { std::env::remove_var(PERMISSIONS_ENV) };
         assert_eq!(permission_default(), PermissionMode::Ask);
-        assert_eq!(permission_mode_for("run_command"), PermissionMode::Ask);
+        assert_eq!(permission_mode_explicit("run_command"), None);
 
         let mut settings = load();
         settings.permissions.default = PermissionMode::Allow;
@@ -305,16 +290,18 @@ mod tests {
             .insert("delete_file".to_string(), PermissionMode::Deny);
         store(&settings).unwrap();
         assert_eq!(permission_default(), PermissionMode::Allow);
-        assert_eq!(permission_mode_for("run_command"), PermissionMode::Allow);
-        assert_eq!(permission_mode_for("delete_file"), PermissionMode::Deny);
+        assert_eq!(permission_mode_explicit("run_command"), None);
+        assert_eq!(
+            permission_mode_explicit("delete_file"),
+            Some(PermissionMode::Deny)
+        );
 
         unsafe { std::env::set_var(PERMISSIONS_ENV, "deny") };
         assert_eq!(permission_default(), PermissionMode::Deny);
-        assert_eq!(permission_mode_for("run_command"), PermissionMode::Deny);
         assert_eq!(
-            permission_mode_for("delete_file"),
-            PermissionMode::Deny,
-            "per-tool override still wins"
+            permission_mode_explicit("delete_file"),
+            Some(PermissionMode::Deny),
+            "per-tool override is unaffected by the env var"
         );
         unsafe { std::env::set_var(PERMISSIONS_ENV, "garbage") };
         assert_eq!(

--- a/tests/acp_permissions.rs
+++ b/tests/acp_permissions.rs
@@ -294,6 +294,10 @@ impl AgentUnderTest {
             if message["method"] == "session/update" {
                 updates.push(message["params"]["update"].clone());
             }
+            assert!(
+                message["method"] != "session/request_permission",
+                "unexpected permission request while waiting for response {id}: {message}"
+            );
             if message["id"] == id && message.get("method").is_none() {
                 assert!(
                     message.get("error").is_none(),
@@ -549,6 +553,160 @@ fn successful_config_option_changes_are_rendered_as_system_status_cards() {
             .unwrap_or_default()
             .starts_with("Switched to siGit Code Cloud"),
         "unexpected cloud switch status title: {status}"
+    );
+
+    drop(agent);
+    let _ = std::fs::remove_dir_all(&scratch);
+}
+
+#[test]
+fn auto_permission_mode_runs_mutating_tools_without_asking() {
+    let endpoint = start_fake_endpoint(vec![
+        sse_tool_call("call_1", "run_command", r#"{"command":"echo sigit-auto"}"#),
+        sse_text("done"),
+    ]);
+
+    let scratch = std::env::temp_dir().join(format!("sigit_acp_auto_perm_{}", std::process::id()));
+    let config_dir = scratch.join("config");
+    let cwd = scratch.join("cwd");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    let mut agent = spawn_agent(endpoint.port, &config_dir);
+
+    let id = agent.request(
+        "initialize",
+        json!({"protocolVersion": 1, "clientCapabilities": {}}),
+    );
+    agent.wait_for_response(id);
+
+    let id = agent.request("session/new", json!({"cwd": cwd, "mcpServers": []}));
+    let session_id = agent.wait_for_response(id)["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    let id = agent.request(
+        "session/set_config_option",
+        json!({
+            "sessionId": session_id,
+            "configId": "sigit-permission-mode",
+            "value": "permission-mode-auto",
+        }),
+    );
+    let (response, updates) = agent.wait_for_response_with_updates(id);
+    let permissions = response["result"]["configOptions"]
+        .as_array()
+        .expect("config options")
+        .iter()
+        .find(|option| option["id"] == "sigit-permission-mode")
+        .expect("permissions config option");
+    assert_eq!(permissions["currentValue"], "permission-mode-auto");
+    assert!(
+        !updates
+            .iter()
+            .any(|update| update["sessionUpdate"] == "agent_message_chunk"),
+        "Permissions picker changes are passive UI state, not chat text: {updates:?}"
+    );
+
+    let prompt_id = agent.request(
+        "session/prompt",
+        json!({
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": "run the command"}],
+        }),
+    );
+    let (response, _updates) = agent.wait_for_response_with_updates(prompt_id);
+    assert_eq!(response["result"]["stopReason"], "end_turn");
+
+    let requests = endpoint.requests.lock().unwrap();
+    assert_eq!(requests.len(), 2, "expected tool round and final round");
+    let messages = requests[1]["messages"].as_array().expect("messages");
+    let result = messages
+        .iter()
+        .find(|message| message["role"] == "tool" && message["tool_call_id"] == "call_1")
+        .expect("tool result for the automatic call");
+    assert!(
+        result["content"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("sigit-auto"),
+        "automatic command output should reach the endpoint: {result}"
+    );
+
+    drop(agent);
+    let _ = std::fs::remove_dir_all(&scratch);
+}
+
+#[test]
+fn plan_permission_mode_denies_mutating_tools_without_asking() {
+    let endpoint = start_fake_endpoint(vec![
+        sse_tool_call("call_1", "run_command", r#"{"command":"echo sigit-plan"}"#),
+        sse_text("planned"),
+    ]);
+
+    let scratch = std::env::temp_dir().join(format!("sigit_acp_plan_perm_{}", std::process::id()));
+    let config_dir = scratch.join("config");
+    let cwd = scratch.join("cwd");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    let mut agent = spawn_agent(endpoint.port, &config_dir);
+
+    let id = agent.request(
+        "initialize",
+        json!({"protocolVersion": 1, "clientCapabilities": {}}),
+    );
+    agent.wait_for_response(id);
+
+    let id = agent.request("session/new", json!({"cwd": cwd, "mcpServers": []}));
+    let session_id = agent.wait_for_response(id)["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    let id = agent.request(
+        "session/set_config_option",
+        json!({
+            "sessionId": session_id,
+            "configId": "sigit-permission-mode",
+            "value": "permission-mode-plan",
+        }),
+    );
+    let (response, _updates) = agent.wait_for_response_with_updates(id);
+    let permissions = response["result"]["configOptions"]
+        .as_array()
+        .expect("config options")
+        .iter()
+        .find(|option| option["id"] == "sigit-permission-mode")
+        .expect("permissions config option");
+    assert_eq!(permissions["currentValue"], "permission-mode-plan");
+
+    let prompt_id = agent.request(
+        "session/prompt",
+        json!({
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": "run the command"}],
+        }),
+    );
+    let (response, _updates) = agent.wait_for_response_with_updates(prompt_id);
+    assert_eq!(response["result"]["stopReason"], "end_turn");
+
+    let requests = endpoint.requests.lock().unwrap();
+    assert_eq!(
+        requests.len(),
+        2,
+        "expected denied tool round and final round"
+    );
+    let messages = requests[1]["messages"].as_array().expect("messages");
+    let result = messages
+        .iter()
+        .find(|message| message["role"] == "tool" && message["tool_call_id"] == "call_1")
+        .expect("tool result for the blocked call");
+    let content = result["content"].as_str().unwrap_or_default();
+    assert!(
+        content.contains("Plan mode is active") && content.contains("was not executed"),
+        "plan mode should return an instructive denial to the endpoint: {result}"
     );
 
     drop(agent);


### PR DESCRIPTION
## Summary
- add a session-scoped ACP Permissions selector with Manual, Auto, and Plan modes
- wire the selector into permission decisions while preserving explicit tool/rule precedence
- keep the selector synced with /plan and /clear

Fixes #76.

## Verification
- cargo fmt -- --check
- cargo clippy --tests -- -D warnings
- cargo test --locked
- ACP smoke via node .claude/skills/run-sigit/driver.mjs